### PR TITLE
Don't append newlines inside a span

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -259,6 +259,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.abbr_data = None  # last inner HTML (for abbr being defined)
         self.abbr_list = {}  # stack of abbreviations to write later
         self.baseurl = baseurl
+        self.in_span = False
 
         try:
             del unifiable_n[name2cp('nbsp')]
@@ -450,7 +451,8 @@ class HTML2Text(HTMLParser.HTMLParser):
                 else:
                     self.soft_br()
             else:
-                self.p()
+                if start == 1 or not self.in_span:
+                    self.p()
 
         if tag == "br" and start:
             self.o("  \n")
@@ -541,12 +543,14 @@ class HTML2Text(HTMLParser.HTMLParser):
                                 a['outcount'] = self.outcount
                                 self.a.append(a)
                             self.o("][" + str(a['count']) + "]")
+                        self.in_span = False
 
         if tag == "img" and start and not self.ignore_images:
             if ('src' in attrs):
                 attrs['href'] = attrs['src']
                 alt = attrs.get('alt', '')
                 self.o("![" + escape_md(alt) + "]")
+                self.in_span = False
 
                 if self.inline_links:
                     self.o("(" + escape_md(attrs['href']) + ")")
@@ -560,6 +564,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                         attrs['outcount'] = self.outcount
                         self.a.append(attrs)
                     self.o("[" + str(attrs['count']) + "]")
+                self.in_span = False
 
         if tag == 'dl' and start:
             self.p()
@@ -748,6 +753,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                 return
             else:
                 self.o("[")
+                self.in_span = True
                 self.maybe_automatic_link = None
 
         if not self.code and not self.pre:


### PR DESCRIPTION
(cherry picked from commit adb2f21897d9aa8233c9851ea89f2aa6c41df8a3)

I think this is the only piece of https://github.com/aaronsw/html2text/pull/87 which really matters, everything else is just a testing and non-sense messing with metadata.
