### PR TITLE
Don't hardcode the path to the installed binary

### DIFF
--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -39,8 +39,7 @@ def test_module(fn, google_doc=False, **kwargs):
 
 def test_command(fn, *args):
     args = list(args)
-    cmd_name = os.path.join(os.path.dirname(fn), '..', 'html2text/__init__.py')
-    cmd = [sys.executable, cmd_name]
+    cmd = [sys.executable, '-m', 'html2text.__init__']
 
     if '--googledoc' in args:
         args.remove('--googledoc')


### PR DESCRIPTION
This allows us to run the same test suite against an installed version
of the library.
