### PR TITLE
added a images_to_alt option to discard images and keep only their alt

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -58,6 +58,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.google_list_indent = config.GOOGLE_LIST_INDENT
         self.ignore_links = config.IGNORE_ANCHORS
         self.ignore_images = config.IGNORE_IMAGES
+        self.images_to_alt = config.IMAGES_TO_ALT
         self.ignore_emphasis = config.IGNORE_EMPHASIS
         self.bypass_tables = config.BYPASS_TABLES
         self.google_doc = False
@@ -390,23 +391,29 @@ class HTML2Text(HTMLParser.HTMLParser):
 
         if tag == "img" and start and not self.ignore_images:
             if 'src' in attrs:
-                attrs['href'] = attrs['src']
+                if not self.images_to_alt:
+                    attrs['href'] = attrs['src']
                 alt = attrs.get('alt') or ''
-                self.o("![" + escape_md(alt) + "]")
 
-                if self.inline_links:
-                    href = attrs.get('href') or ''
-                    self.o("(" + escape_md(href) + ")")
+                # If we have images_to_alt, we discard the image itself,
+                # considering only the alt text.
+                if self.images_to_alt:
+                    self.o(escape_md(alt))
                 else:
-                    i = self.previousIndex(attrs)
-                    if i is not None:
-                        attrs = self.a[i]
+                    self.o("![" + escape_md(alt) + "]")
+                    if self.inline_links:
+                        href = attrs.get('href') or ''
+                        self.o("(" + escape_md(href) + ")")
                     else:
-                        self.acount += 1
-                        attrs['count'] = self.acount
-                        attrs['outcount'] = self.outcount
-                        self.a.append(attrs)
-                    self.o("[" + str(attrs['count']) + "]")
+                        i = self.previousIndex(attrs)
+                        if i is not None:
+                            attrs = self.a[i]
+                        else:
+                            self.acount += 1
+                            attrs['count'] = self.acount
+                            attrs['outcount'] = self.outcount
+                            self.a.append(attrs)
+                        self.o("[" + str(attrs['count']) + "]")
 
         if tag == 'dl' and start:
             self.p()

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -31,6 +31,13 @@ def main():
         help="don't include any formatting for images"
     )
     p.add_option(
+        "--images-to-alt",
+        dest="images_to_alt",
+        action="store_true",
+        default=config.IMAGES_TO_ALT,
+        help="Discard image data, only keep alt text"
+    )
+    p.add_option(
         "-g", "--google-doc",
         action="store_true",
         dest="google_doc",
@@ -140,6 +147,7 @@ def main():
     h.ignore_emphasis = options.ignore_emphasis
     h.ignore_links = options.ignore_links
     h.ignore_images = options.ignore_images
+    h.images_to_alt = options.images_to_alt
     h.google_doc = options.google_doc
     h.hide_strikethrough = options.hide_strikethrough
     h.escape_snob = options.escape_snob

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -25,6 +25,7 @@ GOOGLE_LIST_INDENT = 36
 
 IGNORE_ANCHORS = False
 IGNORE_IMAGES = False
+IMAGES_TO_ALT = False
 IGNORE_EMPHASIS = False
 
 # For checking space-only lines on line 771

--- a/test/images_to_alt.html
+++ b/test/images_to_alt.html
@@ -1,0 +1,3 @@
+<a href="http://example.com">
+<img src="http://example.com/img.png" alt="ALT TEXT" />
+</a>

--- a/test/images_to_alt.md
+++ b/test/images_to_alt.md
@@ -1,0 +1,2 @@
+[ ALT TEXT ](http://example.com)
+

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -127,6 +127,10 @@ def generate_test(fn):
         module_args['body_width'] = 0
         cmdline_args.append('--body-width=0')
 
+    if base_fn.startswith('images_to_alt'):
+        module_args['images_to_alt'] = True
+        cmdline_args.append('--images-to-alt')
+
     return test_mod, test_cmd
 
 # Originally from http://stackoverflow.com/questions/32899/\


### PR DESCRIPTION
That's specially useful when you have big banner images in emails with an alt name.
