### PR TITLE
<a> tags with no text or <img> tags no longer discarded.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,6 +11,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Ivan Gromov <summer.is.gone@gmail.com>
 * Jocelyn Delalande <jdelalande@oasiswork.fr>
 * Matt Dorn <matt.dorn@gmail.com>
+* Miguel Tavares <mgontav@gmail.com>
 
 Maintainer:
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,10 @@
+2015.02.18
+==========
+----
+
+* Fix #38: Anchor tags with empty text or with `<img>` tags inside are no longer stripped.
+
+
 2014.12.29
 ==========
 ----

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class RunTests(Command):
 
 setup(
     name="html2text",
-    version="2014.12.29",
+    version="2015.02.18",
     description="Turn HTML into equivalent Markdown-structured text.",
     author="Aaron Swartz",
     author_email="me@aaronsw.com",

--- a/test/empty-link.html
+++ b/test/empty-link.html
@@ -1,0 +1,6 @@
+<h1>Processing empty hyperlinks</h1>
+
+<p>This test checks wheter empty hyperlinks still appear in the markdown result.</p>
+
+<a href="http://some.link"></a>
+<a href="http://some.link"><p></p></a>

--- a/test/empty-link.md
+++ b/test/empty-link.md
@@ -1,0 +1,8 @@
+# Processing empty hyperlinks
+
+This test checks wheter empty hyperlinks still appear in the markdown result.
+
+[](http://some.link)
+
+[](http://some.link)
+

--- a/test/images_to_alt.html
+++ b/test/images_to_alt.html
@@ -1,3 +1,5 @@
 <a href="http://example.com">
 <img src="http://example.com/img.png" alt="ALT TEXT" />
 </a>
+<br>
+<a href="http://example.com"><img src="http://example.com/img.png" alt="ALT TEXT" /></a>

--- a/test/images_to_alt.html
+++ b/test/images_to_alt.html
@@ -3,3 +3,5 @@
 </a>
 <br>
 <a href="http://example.com"><img src="http://example.com/img.png" alt="ALT TEXT" /></a>
+<br>
+<a href="http://example.com"><img src="http://example.com/img.png" alt="http://example.com" /></a>

--- a/test/images_to_alt.md
+++ b/test/images_to_alt.md
@@ -1,2 +1,3 @@
-[ ALT TEXT ](http://example.com)
+[ ALT TEXT ](http://example.com)  
+[ALT TEXT](http://example.com)
 

--- a/test/images_to_alt.md
+++ b/test/images_to_alt.md
@@ -1,3 +1,4 @@
 [ ALT TEXT ](http://example.com)  
-[ALT TEXT](http://example.com)
+[ALT TEXT](http://example.com)  
+<http://example.com>
 

--- a/test/img-tag-with-link.html
+++ b/test/img-tag-with-link.html
@@ -1,0 +1,9 @@
+<h1>Processing images with links</h1>
+
+<p>This test checks images with associated links.</p>
+
+<a href="http://some.link"><img src="http://placehold.it/350x150#(banana)" width="350" height="150" alt="(banana)"></a>
+<a href="http://some.link"><img src="http://placehold.it/350x150#[banana]" width="350" height="150" alt="[banana]"></a>
+<a href="http://some.link"><img src="http://placehold.it/350x150#{banana}" width="350" height="150" alt="{banana}"></a>
+<a href="http://some.link"><img src="http://placehold.it/350x150#([{}])" width="350" height="150" alt="([{}])"></a>
+<a href="http://some.link"><img src="http://placehold.it/350x150#([{}])" width="350" height="150" alt></a>

--- a/test/img-tag-with-link.md
+++ b/test/img-tag-with-link.md
@@ -1,0 +1,10 @@
+# Processing images with links
+
+This test checks images with associated links.
+
+[![\(banana\)](http://placehold.it/350x150#\(banana\))](http://some.link)
+[![\[banana\]](http://placehold.it/350x150#\[banana\])](http://some.link)
+[![{banana}](http://placehold.it/350x150#{banana})](http://some.link)
+[![\(\[{}\]\)](http://placehold.it/350x150#\(\[{}\]\))](http://some.link)
+[![](http://placehold.it/350x150#\(\[{}\]\))](http://some.link)
+


### PR DESCRIPTION
Following the discussion in https://github.com/Alir3z4/html2text/issues/33.

It both allows for `<img>` tags inside anchor tags as well as empty anchor tags (eg. `<a href="google.com"></a>`) as they represent information that was being left out of the result. Also works with the `images_to_alt' flag, with the alt text being kept as the text part of the link (the previous implementation didn't allow for inline nesting of the <a> and <img> tags).