### PR TITLE
Treat '-' file parameter as stdin

### DIFF
--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -118,7 +118,7 @@ def main():
 
     # process input
     encoding = "utf-8"
-    if len(args) > 0:
+    if len(args) > 0 and args[0] != '-':
         file_ = args[0]
         if len(args) == 2:
             encoding = args[1]


### PR DESCRIPTION
Adds compatibility for a common way to express reading from stdin.