### PR TITLE
Retain escaping of html except within code or pre tags.

### DIFF
--- a/test/html-escaping.html
+++ b/test/html-escaping.html
@@ -1,0 +1,3 @@
+<p>Escaped HTML like &lt;div&gt; or &amp; should remain escaped on output</p>
+<pre>...unless that escaped HTML is in a &lt;pre&gt; tag</pre>
+<code>...or a &lt;code&gt; tag</code>

--- a/test/html-escaping.md
+++ b/test/html-escaping.md
@@ -1,0 +1,8 @@
+Escaped HTML like &lt;div&gt; or &amp; should remain escaped on output
+
+    
+    
+    ...unless that escaped HTML is in a <pre> tag
+
+`...or a <code> tag`
+


### PR DESCRIPTION
Escaped HTML entities do not remain escaped on output.

For example:
`<p>&lt;div&gt;</p>` yields `<div>` in the output markdown, when it should yield `&lt;div&gt;`. The exception is within pre or code tags, which do not need the escaping.

This code was taken from a pull request by @brondsem on the @aaronsw repo that was never merged or closed: https://github.com/aaronsw/html2text/pull/59