### PR TITLE
Support for image sizing using raw html

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+2015.4.14
+=========
+----
+
+
+* Feature #59: Write image tags with height and width attrs as raw html to retain dimensions
+
+
 2015.4.13
 =========
 ----

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ html2text is a Python script that converts a page of HTML into clean, easy-to-re
 Usage: `html2text [(filename|url) [encoding]]`
 
 
-| Option                                                 | Description            
+| Option                                                 | Description
 |--------------------------------------------------------|---------------------------------------------------
-| `--version`                                            | Show program's version number and exit 
-| `-h`, `--help`                                         | Show this help message and exit      
+| `--version`                                            | Show program's version number and exit
+| `-h`, `--help`                                         | Show this help message and exit
 | `--ignore-links`                                       | Don't include any formatting for links
 |`--protect-links`                                       | Protect links from line breaks surrounding them "+" with angle brackets
 |`--ignore-images`                                       | Don't include any formatting for images
 |`--images-to-alt`                                       | Discard image data, only keep alt text
+|`--images-with-size`                                    | Write image tags with height and width attrs as raw html to retain dimensions
 |`-g`, `--google-doc`                                    | Convert an html-exported Google Document
 |`-d`, `--dash-unordered-list`                           | Use a dash rather than a star for unordered list items
 |`-b` `BODY_WIDTH`, `--body-width`=`BODY_WIDTH`          | Number of characters per output line, `0` for no wrap
@@ -48,7 +49,7 @@ Or you can use it from within `Python`:
 Or with some configuration options:
 ```
 >>> import html2text
->>> 
+>>>
 >>> h = html2text.HTML2Text()
 >>> # Ignore converting links from HTML
 >>> h.ignore_links = True

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -61,6 +61,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.ignore_links = config.IGNORE_ANCHORS
         self.ignore_images = config.IGNORE_IMAGES
         self.images_to_alt = config.IMAGES_TO_ALT
+        self.images_with_size = config.IMAGES_WITH_SIZE
         self.ignore_emphasis = config.IGNORE_EMPHASIS
         self.bypass_tables = config.BYPASS_TABLES
         self.google_doc = False
@@ -412,6 +413,20 @@ class HTML2Text(HTMLParser.HTMLParser):
                 if not self.images_to_alt:
                     attrs['href'] = attrs['src']
                 alt = attrs.get('alt') or ''
+
+                # If we have images_with_size, write raw html including width,
+                # height, and alt attributes
+                if self.images_with_size and \
+                        ("width" in attrs or "height" in attrs):
+                    self.o("<img src='" + attrs["src"] + "' ")
+                    if "width" in attrs:
+                        self.o("width='" + attrs["width"] + "' ")
+                    if "height" in attrs:
+                        self.o("height='" + attrs["height"] + "' ")
+                    if alt:
+                        self.o("alt='" + alt + "' ")
+                    self.o("/>")
+                    return
 
                 # If we have a link to create, output the start
                 if not self.maybe_automatic_link is None:

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -49,7 +49,8 @@ def main():
         dest="images_with_size",
         action="store_true",
         default=config.IMAGES_WITH_SIZE,
-        help="Write image tags as raw html with height and width attrs"
+        help="Write image tags with height and width attrs as raw html to "
+             "retain dimensions"
     )
     p.add_option(
         "-g", "--google-doc",

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -45,6 +45,13 @@ def main():
         help="Discard image data, only keep alt text"
     )
     p.add_option(
+        "--images-with-size",
+        dest="images_with_size",
+        action="store_true",
+        default=config.IMAGES_WITH_SIZE,
+        help="Write image tags as raw html with height and width attrs"
+    )
+    p.add_option(
         "-g", "--google-doc",
         action="store_true",
         dest="google_doc",
@@ -166,6 +173,7 @@ def main():
     h.protect_links = options.protect_links
     h.ignore_images = options.ignore_images
     h.images_to_alt = options.images_to_alt
+    h.images_with_size = options.images_with_size
     h.google_doc = options.google_doc
     h.hide_strikethrough = options.hide_strikethrough
     h.escape_snob = options.escape_snob

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -30,6 +30,7 @@ GOOGLE_LIST_INDENT = 36
 IGNORE_ANCHORS = False
 IGNORE_IMAGES = False
 IMAGES_TO_ALT = False
+IMAGES_WITH_SIZE = False
 IGNORE_EMPHASIS = False
 
 # For checking space-only lines on line 771

--- a/test/images_with_size.html
+++ b/test/images_with_size.html
@@ -1,0 +1,7 @@
+<img src='image_without_dimensions.jpg' alt='An image without dimensions' style='ignored-style' />
+
+<img src='image_with_width.jpg' alt='An image with a width attr' width='300' data-ignored='ignored data' />
+
+<img src='image_with_width.jpg' alt='An image with a height attr' height='300' data-ignored='ignored data' />
+
+<img src='image_with_width_and_height.jpg' alt='An image with width and height' width='300' height='300' id='ignored-id' />

--- a/test/images_with_size.md
+++ b/test/images_with_size.md
@@ -1,0 +1,6 @@
+![An image without dimensions](image_without_dimensions.jpg) <img
+src='image_with_width.jpg' width='300' alt='An image with a width attr' />
+<img src='image_with_width.jpg' height='300' alt='An image with a height attr'
+/> <img src='image_with_width_and_height.jpg' width='300' height='300' alt='An
+image with width and height' />
+

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -135,6 +135,10 @@ def generate_test(fn):
         module_args['images_to_alt'] = True
         cmdline_args.append('--images-to-alt')
 
+    if base_fn.startswith('images_with_size'):
+        module_args['images_with_size'] = True
+        cmdline_args.append('--images-with-size')
+
     if base_fn.startswith('single_line_break'):
         module_args['body_width'] = 0
         cmdline_args.append('--body-width=0')


### PR DESCRIPTION
Given that there isn't a standard for specifying image dimensions in markdown, fall back to using raw html (sanitized to only contain src, alt, width, and height attributes) when dimensions are desired.

http://daringfireball.net/projects/markdown/syntax#img