### PR TITLE
Proper handling of anchors with content that starts with tags that

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -275,6 +275,13 @@ class HTML2Text(HTMLParser.HTMLParser):
         else:
             attrs = dict(attrs)
 
+        # first thing inside the anchor tag is another tag that produces some output
+        if start and not self.maybe_automatic_link is None and \
+             tag not in ['p', 'div', 'style', 'dl', 'dt'] and (tag != "img" or self.ignore_images):
+            self.o("[")
+            self.maybe_automatic_link = None
+            self.empty_link = False
+
         if self.google_doc:
             # the attrs parameter is empty for a closing tag. in addition, we
             # need the attributes of the parent nodes in order to get a

--- a/test/anchors.html
+++ b/test/anchors.html
@@ -1,0 +1,7 @@
+<h1>Processing hyperlinks</h1>
+
+<p>Additional hyperlink tests!</p>
+
+<a href="http://some.link"><b>Bold Link</b></a>
+<a href="http://some.link/filename.py"><code>filename.py</code></a>
+<a href="http://some.link/magicsources.py">The source code is called <code>magic.py</code></a>

--- a/test/anchors.md
+++ b/test/anchors.md
@@ -1,0 +1,8 @@
+# Processing hyperlinks
+
+Additional hyperlink tests!
+
+[**Bold Link**](http://some.link)
+[`filename.py`](http://some.link/filename.py) [The source code is called
+`magic.py`](http://some.link/magicsources.py)
+


### PR DESCRIPTION
produce markdown (such as <code>, <b>, etc.).

This addresses the following issues:

https://github.com/Alir3z4/html2text/issues/63
https://github.com/Alir3z4/html2text/issues/24