### PR TITLE
Issue #61. Malformed links in MD output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 *.egg-info
 .idea
 .coverage
+env/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Miguel Tavares <mgontav@gmail.com>
 * Scott Blackburn <scott@skipflag.com>
 * Peter Wu <peter@lekensteyn.nl>
+* Arjoonn Sharma <gh: theSage21>
 
 
 Maintainer:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -69,6 +69,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.emphasis_mark = '_'
         self.strong_mark = '**'
         self.single_line_break = config.SINGLE_LINE_BREAK
+        self.use_automatic_links = config.USE_AUTOMATIC_LINKS
 
         if out is None:
             self.out = self.outtextf
@@ -677,7 +678,7 @@ class HTML2Text(HTMLParser.HTMLParser):
 
         if not self.maybe_automatic_link is None:
             href = self.maybe_automatic_link
-            if href == data and self.absolute_url_matcher.match(href):
+            if href == data and self.absolute_url_matcher.match(href) and self.use_automatic_links:
                 self.o("<" + data + ">")
                 self.empty_link = False
                 return

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -33,6 +33,9 @@ IMAGES_TO_ALT = False
 IMAGES_WITH_SIZE = False
 IGNORE_EMPHASIS = False
 
+# Convert links with same href and text to <href> format if they are absolute links
+USE_AUTOMATIC_LINKS = True
+
 # For checking space-only lines on line 771
 RE_SPACE = re.compile(r'\s\+')
 


### PR DESCRIPTION
Since this was obviously intended as seen in the design, but Daring Fireball is silent on the conversion
of automatic links, I have added an option in the module to deactivate the use of automatic links.

This way those who want it can still use it and those who prefer to follow the Daring Fireball version of MD, can opt out of the feature.