### PR TITLE
Added --mark-code option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Usage: `html2text [(filename|url) [encoding]]`
 | `--bypass-tables`                                      | Format tables in HTML rather than Markdown syntax.
 | `--single-line-break`                                  | Use a single line break after a block element rather than two.
 | `--reference-links`                                    | Use reference links instead of links to create markdown
+| `--mark-code`                                          | Mark preformatted and code blocks with [code]...[/code]
 
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,6 +78,7 @@ simple indications of their function.
     - RE_SLASH_CHARS a string of slash escapeable characters
     - RE_MD_BACKSLASH_MATCHER to match \char
     - USE_AUTOMATIC_LINKS to convert <a href='http://xyz'>http://xyz</a> to <http://xyz>
+    - MARK_CODE to wrap 'pre' blocks with [code]...[/code] tags
 
 To alter any option the procedure is to create a parser with
 `parser = html2text.HTML2Text()` and to set the option on the parser.

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -70,6 +70,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.strong_mark = '**'
         self.single_line_break = config.SINGLE_LINE_BREAK
         self.use_automatic_links = config.USE_AUTOMATIC_LINKS
+        self.mark_code = config.MARK_CODE
 
         if out is None:
             self.out = self.outtextf
@@ -561,6 +562,8 @@ class HTML2Text(HTMLParser.HTMLParser):
                 self.pre = 1
             else:
                 self.pre = 0
+                if self.mark_code:
+                    self.out("\n[/code]")
             self.p()
 
     # TODO: Add docstring for these one letter functions
@@ -607,6 +610,9 @@ class HTML2Text(HTMLParser.HTMLParser):
                 #self.out(" :") #TODO: not output when already one there
                 if not data.startswith("\n"):  # <pre>stuff...
                     data = "\n" + data
+                if self.mark_code:
+                    self.out("\n[code]")
+                    self.p_p = 0
 
             bq = (">" * self.blockquote)
             if not (force and data and data[0] == ">") and self.blockquote:

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -131,6 +131,13 @@ def main():
             "line breaks. NOTE: Requires --body-width=0"
         )
     )
+    p.add_option(
+        "--mark-code",
+        action="store_true",
+        dest="mark_code",
+        default=config.MARK_CODE,
+        help="Mark program code blocks with [code]...[/code]"
+    )    
     (options, args) = p.parse_args()
 
     # process input
@@ -190,5 +197,6 @@ def main():
     h.bypass_tables = options.bypass_tables
     h.single_line_break = options.single_line_break
     h.inline_links = options.inline_links
+    h.mark_code = options.mark_code
 
     wrapwrite(h.handle(data))

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -32,6 +32,7 @@ IGNORE_IMAGES = False
 IMAGES_TO_ALT = False
 IMAGES_WITH_SIZE = False
 IGNORE_EMPHASIS = False
+MARK_CODE = False
 
 # Convert links with same href and text to <href> format if they are absolute links
 USE_AUTOMATIC_LINKS = True

--- a/test/mark_code.html
+++ b/test/mark_code.html
@@ -1,0 +1,12 @@
+<html>
+  <body>
+<p>Normal text with 'pre' code block.</p>
+<pre>
+import os
+
+def function():
+    a = 1
+</pre>
+<p>Normal text continues.</p>
+</body>
+</html>

--- a/test/mark_code.md
+++ b/test/mark_code.md
@@ -1,0 +1,13 @@
+Normal text with 'pre' code block.
+
+[code]
+
+    import os
+    
+    def function():
+        a = 1
+    
+[/code]
+
+Normal text continues.
+

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -149,6 +149,10 @@ def generate_test(fn):
         module_args['inline_links'] = False
         cmdline_args.append('--reference-links')
 
+    if base_fn.startswith('mark_code'):
+        module_args['mark_code'] = True
+        cmdline_args.append('--mark-code')
+        
     return test_mod, test_cmd
 
 # Originally from http://stackoverflow.com/questions/32899/\


### PR DESCRIPTION
For making 'pre' blocks clearer for further automatic formatting:
```
Here normal text with test code block:

[code]

    use v6;
    use Test;
    use lib 'lib';
    
    plan $num-tests
    
[/code]

Here normal text continues.
```