### PR TITLE
Link titles are no longer lost in inline links.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -110,4 +110,4 @@
 * Fix #71: Coverage detects command line tests
 * Fix #39: Documentation update
 * Fix #61: Functionality added for optional use of automatic links
-
+* Feature #80: 'title' attribute is preserved in both inline and reference links

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -200,6 +200,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                 if ('title' in a) or ('title' in attrs):
                     if (('title' in a) and ('title' in attrs) and
                                 a['title'] == attrs['title']):
+                        print(a['title'], attrs['title'])
                         match = True
                 else:
                     match = True
@@ -404,7 +405,13 @@ class HTML2Text(HTMLParser.HTMLParser):
                             self.empty_link = False
                             self.maybe_automatic_link = None
                         if self.inline_links:
-                            self.o("](" + escape_md(a['href']) + ")")
+                            try:
+                                title = escape_md(a['title'])
+                            except KeyError:
+                                self.o("](" + escape_md(a['href']) + ")")
+                            else:
+                                self.o("](" + escape_md(a['href'])
+                                       + ' "' + title + '" )')
                         else:
                             i = self.previousIndex(a)
                             if i is not None:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -200,7 +200,6 @@ class HTML2Text(HTMLParser.HTMLParser):
                 if ('title' in a) or ('title' in attrs):
                     if (('title' in a) and ('title' in attrs) and
                                 a['title'] == attrs['title']):
-                        print(a['title'], attrs['title'])
                         match = True
                 else:
                     match = True

--- a/test/link_titles.html
+++ b/test/link_titles.html
@@ -1,0 +1,1 @@
+<a href="htt://example.com" title="MyTitle"> an example</a> inline link

--- a/test/link_titles.html
+++ b/test/link_titles.html
@@ -1,1 +1,3 @@
-<a href="htt://example.com" title="MyTitle"> an example</a> inline link
+<a href="http://example.com" title="MyTitle"> first example</a>
+<br>
+<a href="http://example.com" > second example</a>

--- a/test/link_titles.md
+++ b/test/link_titles.md
@@ -1,2 +1,3 @@
-[ an example](http://example.com/ "MyTitle")
+[ first example](http://example.com "MyTitle" )  
+[ second example](http://example.com)
 

--- a/test/link_titles.md
+++ b/test/link_titles.md
@@ -1,0 +1,2 @@
+[ an example](http://example.com/ "MyTitle")
+


### PR DESCRIPTION
Fix for #69. Inline links now have titles in them.