### PR TITLE
Make bodywidth kwarg overridable using config

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Arjoonn Sharma <gh: theSage21>
 * Ali Mohammad <gh: alawibaba>
 * Albert Berger <gh: nbdsp>
+* Etienne Millon <me@emillon.org>
 
 
 Maintainer:

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,7 @@
 * Fix #61: Functionality added for optional use of automatic links.
 * Feature #80: ``title`` attribute is preserved in both inline and reference links.
 * Feature #82: More command line options. See docs.
+* Fix #84: Make bodywidth kwarg overridable using config.
 
 
 2015.6.12

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -819,7 +819,9 @@ class HTML2Text(HTMLParser.HTMLParser):
         return result
 
 
-def html2text(html, baseurl='', bodywidth=config.BODY_WIDTH):
+def html2text(html, baseurl='', bodywidth=None):
+    if bodywidth is None:
+        bodywidth = config.BODY_WIDTH
     h = HTML2Text(baseurl=baseurl, bodywidth=bodywidth)
 
     return h.handle(html)


### PR DESCRIPTION
Hey,

I believe I hit a problem with your library.

Default values for arguments are evaluated at import time.
This makes a problem when using html2text the following way:

    import html2text  # The default value is evaluated here
    html2text.config.BODY_WIDTH = 0
    text = html2text.html2text(html)

It is thus necessary to wait until the function runs to fetch the actual
configuration value.

Thanks for maintaining html2text!