### PR TITLE
Long links wrapping option

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,10 @@
+0000.0.00
+=========
+----
+
+* Fix #38: Long links wrapping controlled by `--no-wrap-links`.
+* Note: `--no-wrap-links` implies `--reference-links`
+
 2015.6.21
 =========
 ----

--- a/README.md
+++ b/README.md
@@ -15,27 +15,16 @@ html2text is a Python script that converts a page of HTML into clean, easy-to-re
 
 Usage: `html2text [(filename|url) [encoding]]`
 
-
 | Option                                                 | Description
 |--------------------------------------------------------|---------------------------------------------------
 | `--version`                                            | Show program's version number and exit
 | `-h`, `--help`                                         | Show this help message and exit
 | `--ignore-links`                                       | Don't include any formatting for links
-|`--protect-links`                                       | Protect links from line breaks surrounding them "+" with angle brackets
-|`--ignore-images`                                       | Don't include any formatting for images
-|`--images-to-alt`                                       | Discard image data, only keep alt text
-|`--images-with-size`                                    | Write image tags with height and width attrs as raw html to retain dimensions
-|`-g`, `--google-doc`                                    | Convert an html-exported Google Document
-|`-d`, `--dash-unordered-list`                           | Use a dash rather than a star for unordered list items
-|`-b` `BODY_WIDTH`, `--body-width`=`BODY_WIDTH`          | Number of characters per output line, `0` for no wrap
-|`-i` `LIST_INDENT`, `--google-list-indent`=`LIST_INDENT`| Number of pixels Google indents nested lists
-|`-s`, `--hide-strikethrough`                            | Hide strike-through text. only relevent when `-g` is specified as well
 |`--escape-all`                                          | Escape all special characters.  Output is less readable, but avoids corner case formatting issues.
-| `--bypass-tables`                                      | Format tables in HTML rather than Markdown syntax.
-| `--single-line-break`                                  | Use a single line break after a block element rather than two.
 | `--reference-links`                                    | Use reference links instead of links to create markdown
 | `--mark-code`                                          | Mark preformatted and code blocks with [code]...[/code]
 
+For a complete list of options see the [docs](docs/usage.md)
 
 
 Or you can use it from within `Python`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,7 @@ simple indications of their function.
     - RE_MD_BACKSLASH_MATCHER to match \char
     - USE_AUTOMATIC_LINKS to convert <a href='http://xyz'>http://xyz</a> to <http://xyz>
     - MARK_CODE to wrap 'pre' blocks with [code]...[/code] tags
+    - WRAP_LINKS to decide if links have to be wrapped during text wrapping
 
 To alter any option the procedure is to create a parser with
 `parser = html2text.HTML2Text()` and to set the option on the parser.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,7 +79,7 @@ simple indications of their function.
     - RE_MD_BACKSLASH_MATCHER to match \char
     - USE_AUTOMATIC_LINKS to convert <a href='http://xyz'>http://xyz</a> to <http://xyz>
     - MARK_CODE to wrap 'pre' blocks with [code]...[/code] tags
-    - WRAP_LINKS to decide if links have to be wrapped during text wrapping
+    - WRAP_LINKS to decide if links have to be wrapped during text wrapping (implies INLINE_LINKS = False)
 
 To alter any option the procedure is to create a parser with
 `parser = html2text.HTML2Text()` and to set the option on the parser.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,3 +115,4 @@ Command line options
 | `--no-skip-internal-links`                             | Turn off skipping of internal links
 | `--links-after-para`                                   | Put the links after the paragraph and not at end of document
 | `--mark-code`                                          | Mark code with [code]...[/code] blocks
+| `--no-wrap-links`                                      | Do not wrap links during text wrapping. Implies `--reference-links`

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -72,6 +72,9 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.use_automatic_links = config.USE_AUTOMATIC_LINKS  # covered in cli
         self.hide_strikethrough = False  # covered in cli
         self.mark_code = config.MARK_CODE
+        self.single_line_break = config.SINGLE_LINE_BREAK
+        self.use_automatic_links = config.USE_AUTOMATIC_LINKS
+        self.wrap_links = config.WRAP_LINKS  # covered in cli
 
         if out is None:  # pragma: no cover
             self.out = self.outtextf
@@ -796,7 +799,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         newlines = 0
         for para in text.split("\n"):
             if len(para) > 0:
-                if not skipwrap(para):
+                if not skipwrap(para, self.wrap_links):
                     result += "\n".join(wrap(para, self.body_width))
                     if para.endswith('  '):
                         result += "  \n"

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -797,6 +797,11 @@ class HTML2Text(HTMLParser.HTMLParser):
         assert wrap, "Requires Python 2.3."
         result = ''
         newlines = 0
+        # I cannot think of a better solution for now.
+        # To avoid the non-wrap behaviour for entire paras
+        # because of the presence of a link in it
+        if not self.wrap_links:
+            self.inline_links = False
         for para in text.split("\n"):
             if len(para) > 0:
                 if not skipwrap(para, self.wrap_links):

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -13,6 +13,13 @@ def main():
         version='%prog ' + ".".join(map(str, __version__))
     )
     p.add_option(
+        "--no-wrap-links",
+        dest="wrap_links",
+        action="store_false",
+        default=config.WRAP_LINKS,
+        help="wrap links during conversion"
+    )
+    p.add_option(
         "--ignore-emphasis",
         dest="ignore_emphasis",
         action="store_true",
@@ -230,5 +237,6 @@ def main():
     h.skip_internal_links = options.skip_internal_links
     h.links_each_paragraph = options.links_each_paragraph
     h.mark_code = options.mark_code
+    h.wrap_links = options.wrap_links
 
     wrapwrite(h.handle(data))

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -23,6 +23,8 @@ INLINE_LINKS = True
 # Protect links from line breaks surrounding them with angle brackets (in
 # addition to their square brackets)
 PROTECT_LINKS = False
+# WRAP_LINKS = True
+WRAP_LINKS = True
 
 # Number of pixels Google indents nested lists
 GOOGLE_LIST_INDENT = 36
@@ -45,6 +47,7 @@ RE_ORDERED_LIST_MATCHER = re.compile(r'\d+\.\s')
 RE_UNORDERED_LIST_MATCHER = re.compile(r'[-\*\+]\s')
 RE_MD_CHARS_MATCHER = re.compile(r"([\\\[\]\(\)])")
 RE_MD_CHARS_MATCHER_ALL = re.compile(r"([`\*_{}\[\]\(\)#!])")
+RE_LINK = re.compile(r"(\[.*?\] ?\(.*?\))|(\[.*?\]:.*?)")  # to find links in the text
 RE_MD_DOT_MATCHER = re.compile(r"""
     ^             # start of line
     (\s*\d+)      # optional whitespace and a number

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -172,7 +172,11 @@ def list_numbering_start(attrs):
     return 0
 
 
-def skipwrap(para):
+def skipwrap(para, wrap_links):
+    # If it appears to contain a link
+    # don't wrap
+    if (len(config.RE_LINK.findall(para)) > 0) and not wrap_links:
+        return True
     # If the text begins with four spaces or one tab, it's a code block;
     # don't wrap
     if para[0:4] == '    ' or para[0] == '\t':

--- a/test/no_wrap_links.html
+++ b/test/no_wrap_links.html
@@ -1,0 +1,1 @@
+And <a href="http://bugs.debian.org/cgi-bin/pkgreport.cgi?tag=multiarch;users=debian-dpkg@lists.debian.org">here</a> is a long link I had at hand.</p>

--- a/test/no_wrap_links.md
+++ b/test/no_wrap_links.md
@@ -1,0 +1,2 @@
+And [here](http://bugs.debian.org/cgi-bin/pkgreport.cgi?tag=multiarch;users=debian-dpkg@lists.debian.org) is a long link I had at hand.
+

--- a/test/no_wrap_links_no_inline_links.html
+++ b/test/no_wrap_links_no_inline_links.html
@@ -1,0 +1,1 @@
+And <a href="http://bugs.debian.org/cgi-bin/pkgreport.cgi?tag=multiarch;users=debian-dpkg@lists.debian.org">here</a> is a long link I had at hand.

--- a/test/no_wrap_links_no_inline_links.md
+++ b/test/no_wrap_links_no_inline_links.md
@@ -1,0 +1,2 @@
+And [here](http://bugs.debian.org/cgi-bin/pkgreport.cgi?tag=multiarch;users=debian-dpkg@lists.debian.org) is a long link I had at hand. 
+

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -148,6 +148,10 @@ def generate_test(fn):
     if base_fn.startswith('no_inline_links'):
         module_args['inline_links'] = False
         cmdline_args.append('--reference-links')
+    
+    if base_fn.startswith('no_wrap_links'):
+        module_args['wrap_links'] = False
+        cmdline_args.append('--no-wrap-links')
 
     if base_fn.startswith('mark_code'):
         module_args['mark_code'] = True


### PR DESCRIPTION
Possible fix for #38 

- urls which are long are not wrapped if so desired.
- old behaviour is maintained to avoid breaking someone's code
- `--no-wrap-links` has been added.
- both inline links and reference links are supported for no wrapping.
- docs have been updated
