### PR TITLE
Decode errors handling via command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,16 @@ html2text is a Python script that converts a page of HTML into clean, easy-to-re
 
 Usage: `html2text [(filename|url) [encoding]]`
 
-
 | Option                                                 | Description
 |--------------------------------------------------------|---------------------------------------------------
 | `--version`                                            | Show program's version number and exit
 | `-h`, `--help`                                         | Show this help message and exit
 | `--ignore-links`                                       | Don't include any formatting for links
-|`--protect-links`                                       | Protect links from line breaks surrounding them "+" with angle brackets
-|`--ignore-images`                                       | Don't include any formatting for images
-|`--images-to-alt`                                       | Discard image data, only keep alt text
-|`--images-with-size`                                    | Write image tags with height and width attrs as raw html to retain dimensions
-|`-g`, `--google-doc`                                    | Convert an html-exported Google Document
-|`-d`, `--dash-unordered-list`                           | Use a dash rather than a star for unordered list items
-|`-b` `BODY_WIDTH`, `--body-width`=`BODY_WIDTH`          | Number of characters per output line, `0` for no wrap
-|`-i` `LIST_INDENT`, `--google-list-indent`=`LIST_INDENT`| Number of pixels Google indents nested lists
-|`-s`, `--hide-strikethrough`                            | Hide strike-through text. only relevent when `-g` is specified as well
 |`--escape-all`                                          | Escape all special characters.  Output is less readable, but avoids corner case formatting issues.
-| `--bypass-tables`                                      | Format tables in HTML rather than Markdown syntax.
-| `--single-line-break`                                  | Use a single line break after a block element rather than two.
 | `--reference-links`                                    | Use reference links instead of links to create markdown
 | `--mark-code`                                          | Mark preformatted and code blocks with [code]...[/code]
 
+For a complete list of options see the [docs](docs/usage.md)
 
 
 Or you can use it from within `Python`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,3 +115,4 @@ Command line options
 | `--no-skip-internal-links`                             | Turn off skipping of internal links
 | `--links-after-para`                                   | Put the links after the paragraph and not at end of document
 | `--mark-code`                                          | Mark code with [code]...[/code] blocks
+| `--no-wrap-links`                                      | Do not wrap links during text wrapping. Implies `--reference-links`

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -8,7 +8,7 @@ from html2text.utils import wrapwrite, wrap_read
 def main():
     baseurl = ''
 
-    class bcolors:
+    class bcolors:  # pragma: no cover
         HEADER = '\033[95m'
         OKBLUE = '\033[94m'
         OKGREEN = '\033[92m'

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -8,6 +8,16 @@ from html2text.utils import wrapwrite, wrap_read
 def main():
     baseurl = ''
 
+    class bcolors:
+        HEADER = '\033[95m'
+        OKBLUE = '\033[94m'
+        OKGREEN = '\033[92m'
+        WARNING = '\033[93m'
+        FAIL = '\033[91m'
+        ENDC = '\033[0m'
+        BOLD = '\033[1m'
+        UNDERLINE = '\033[4m'
+
     p = optparse.OptionParser(
         '%prog [(filename|url) [encoding]]',
         version='%prog ' + ".".join(map(str, __version__))
@@ -217,10 +227,17 @@ def main():
 
     if hasattr(data, 'decode'):
         try:
-            data = data.decode(encoding, errors=options.decode_errors)
-        except TypeError:
-            # python 2.6.x does not have the errors option
-            data = data.decode(encoding)
+            try:
+                data = data.decode(encoding, errors=options.decode_errors)
+            except TypeError:
+                # python 2.6.x does not have the errors option
+                data = data.decode(encoding)
+        except UnicodeDecodeError as err:
+            warning = bcolors.WARNING + "Warning:" + bcolors.ENDC
+            warning += ' Use the ' + bcolors.OKGREEN
+            warning += '--decode-errors=ignore' + bcolors.ENDC + 'flag.'
+            print(warning)
+            raise err
 
     h = HTML2Text(baseurl=baseurl)
     # handle options

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -216,7 +216,11 @@ def main():
         data = wrap_read()
 
     if hasattr(data, 'decode'):
-        data = data.decode(encoding, errors=options.decode_errors)
+        try:
+            data = data.decode(encoding, errors=options.decode_errors)
+        except TypeError:
+            # python 2.6.x does not have the errors option
+            data = data.decode(encoding)
 
     h = HTML2Text(baseurl=baseurl)
     # handle options


### PR DESCRIPTION
Possible fix for #87 

- Decode errors can be configured via command line