### PR TITLE
Add callback feature

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Ali Mohammad <gh: alawibaba>
 * Albert Berger <gh: nbdsp>
 * Etienne Millon <me@emillon.org>
+* John C F <gh: critiqjo>
 
 
 Maintainer:

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,13 @@
 * Note: `--no-wrap-links` implies `--reference-links`
 * Fix #87: Decode errors can be handled via command line.
 
+2015.10.27
+=========
+----
+
+* Feature #83: Add callback-on-tag.
+
+
 2015.6.21
 =========
 ----

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -75,6 +75,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.single_line_break = config.SINGLE_LINE_BREAK
         self.use_automatic_links = config.USE_AUTOMATIC_LINKS
         self.wrap_links = config.WRAP_LINKS  # covered in cli
+        self.tag_callback = None
 
         if out is None:  # pragma: no cover
             self.out = self.outtextf
@@ -280,6 +281,10 @@ class HTML2Text(HTMLParser.HTMLParser):
             attrs = {}
         else:
             attrs = dict(attrs)
+
+        if self.tag_callback is not None:
+            if self.tag_callback(self, tag, attrs, start) is True:
+                return
 
         # first thing inside the anchor tag is another tag that produces some output
         if (start and not self.maybe_automatic_link is None


### PR DESCRIPTION
This PR enables finer-grained control over the output generated. Example usage:

```python
my_em = False
def my_tag_handle(parser, tag, attrs, start):
  global my_em
  if tag == 'em':
    if 'class' in attrs and 'my' in attrs['class'] and start:
      parser.o("[my] ")
      my_em = True
      return True
    elif my_em and not start:
      parser.o("[/my]")
      my_em = False
      return True

parser = html2text.HTML2Text()
parser.tag_callback = my_tag_handle
text = parser.handle(html)
```