### PR TITLE
:bug: fix error end tag pop exception

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -306,7 +306,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                 tag_style = element_style(attrs, self.style_def, parent_style)
                 self.tag_stack.append((tag, attrs, tag_style))
             else:
-                dummy, attrs, tag_style = self.tag_stack.pop()
+                dummy, attrs, tag_style = self.tag_stack.pop() if self.tag_stack else (None, {}, {})
                 if self.tag_stack:
                     parent_style = self.tag_stack[-1][2]
 


### PR DESCRIPTION
If html contain a incorrect end tag, pop on tag_stack will raise exception

For example:
`<div></div></div>`