### PR TITLE
Fix DeprecationWarning on Python3: use html.escape

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -4,7 +4,11 @@
 from __future__ import division
 import re
 import sys
-import cgi
+
+try:
+    from html import escape as html_escape
+except ImportError:
+    from cgi import escape as html_escape
 
 try:
     from textwrap import wrap
@@ -173,14 +177,14 @@ class HTML2Text(HTMLParser.HTMLParser):
     def handle_charref(self, c):
         charref = self.charref(c)
         if not self.code and not self.pre:
-            charref = cgi.escape(charref)
+            charref = html_escape(charref)
         self.handle_data(charref, True)
 
     def handle_entityref(self, c):
         entityref = self.entityref(c)
         if (not self.code and not self.pre
                 and entityref != '&nbsp_place_holder;'):
-            entityref = cgi.escape(entityref)
+            entityref = html_escape(entityref)
         self.handle_data(entityref, True)
 
     def handle_starttag(self, tag, attrs):

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -6,16 +6,11 @@ import re
 import sys
 
 try:
-    from html import escape as html_escape
-except ImportError:
-    from cgi import escape as html_escape
-
-try:
     from textwrap import wrap
 except ImportError:  # pragma: no cover
     pass
 
-from html2text.compat import urlparse, HTMLParser
+from html2text.compat import urlparse, HTMLParser, html_escape
 from html2text import config
 
 from html2text.utils import (

--- a/html2text/compat.py
+++ b/html2text/compat.py
@@ -6,8 +6,12 @@ if sys.version_info[0] == 2:
     import urlparse
     import HTMLParser
     import urllib
+    from cgi import escape as html_escape
 else:
     import urllib.parse as urlparse
     import html.entities as htmlentitydefs
     import html.parser as HTMLParser
     import urllib.request as urllib
+    from html import escape
+    def html_escape(s):
+        return escape(s, quote=False)


### PR DESCRIPTION
Hello,

Python 3 raises a DeprecationWarning when using `cgi.escape`. `html.escape` is the replacement. This PR avoids the warning with a fallback to `cgi.escape` on Python 2.

Thanks!