### PR TITLE
CSS case-insensitive fix

### DIFF
--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -31,7 +31,7 @@ def dumb_property_dict(style):
     """
     :returns: A hash of css attributes
     """
-    out = dict([(x.strip(), y.strip()) for x, y in
+    out = dict([(x.strip().lower(), y.strip().lower()) for x, y in
                 [z.split(':', 1) for z in
                  style.split(';') if ':' in z
                  ]
@@ -149,7 +149,7 @@ def google_fixed_width_font(style):
     font_family = ''
     if 'font-family' in style:
         font_family = style['font-family']
-    if 'Courier New' == font_family or 'Consolas' == font_family:
+    if 'courier new' == font_family or 'consolas' == font_family:
         return True
 
     return False

--- a/test/google-like_font-properties.html
+++ b/test/google-like_font-properties.html
@@ -1,0 +1,15 @@
+<HTML>
+  <HEAD>
+    <TITLE>CAPS-LOCK TEST</TITLE>
+  </HEAD>
+  <BODY>
+    <p><span style="font-weight: bold">font-weight: bold</span></p>
+    <P><SPAN STYLE="FONT-WEIGHT: BOLD">FONT-WEIGHT: BOLD</SPAN></P>
+    <p><span style="font-style: italic">font-style: italic</span></p>
+    <P><SPAN STYLE="FONT-STYLE: ITALIC">FONT-STYLE: ITALIC</SPAN></P>
+    <p><span style="font-weight: bold;font-style: italic">
+      font-weight: bold;font-style: italic</span></p>
+    <P><SPAN STYLE="FONT-WEIGHT: BOLD;FONT-STYLE: ITALIC">
+      FONT-WEIGHT: BOLD;FONT-STYLE: ITALIC</SPAN></P>
+  </BODY>
+</HTML>

--- a/test/google-like_font-properties.md
+++ b/test/google-like_font-properties.md
@@ -1,0 +1,6 @@
+**font-weight: bold**   
+**FONT-WEIGHT: BOLD**   
+_font-style: italic_   
+_FONT-STYLE: ITALIC_   
+_**font-weight: bold;font-style: italic**_   
+_**FONT-WEIGHT: BOLD;FONT-STYLE: ITALIC**_ 


### PR DESCRIPTION
Fix and tests to address CSS case-insensitive issue. Tests are specific to the google_doc flag, and all pass against master HEAD. This should fix issue #132.