### PR TITLE
Remove check for '/script>' in handle_data to fix #133

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -731,9 +731,6 @@ class HTML2Text(HTMLParser.HTMLParser):
             self.outcount += 1
 
     def handle_data(self, data, entity_char=False):
-        if r'\/script>' in data:
-            self.quiet -= 1
-
         if self.style:
             self.style_def.update(dumb_css_parser(data))
 


### PR DESCRIPTION
This fixes the toyrus problem where '/script>' appears inside the data for a <script> tag causing the `self.quiet` count for the HTML2Text instance to go below zero.