### PR TITLE
Fix images link with div wrap

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,7 +2,7 @@
 ==========
 ----
 
-* Merge #157: Fix images link with div wrap
+* Fix #157: Fix images link with div wrap
 
 
 2016.9.19

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,8 @@
 ==========
 ----
 
+* Merge #157: Fix images link with div wrap
+
 
 2016.9.19
 =========

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -331,6 +331,8 @@ class HTML2Text(HTMLParser.HTMLParser):
                     self.p()
                 else:
                     self.soft_br()
+            elif self.astack and tag == 'div':
+                pass
             else:
                 self.p()
 

--- a/test/images_with_div_wrap.html
+++ b/test/images_with_div_wrap.html
@@ -1,0 +1,1 @@
+<a href="http://example.com"><div><img src="http://example.com/img.png"/></div></a>

--- a/test/images_with_div_wrap.md
+++ b/test/images_with_div_wrap.md
@@ -1,0 +1,2 @@
+[![](http://example.com/img.png)](http://example.com)
+


### PR DESCRIPTION
Currently html2text will add extra line breaks while convert image links.

- What the input HTML is
```html
<a href="http://example.com"><div><img src="http://example.com/img.png"/></div></a>
```
- What the output text is
```markdown
[![](http://example.com/img.png)
](http://example.com)
```
- What we expect
```markdown
[![](http://example.com/img.png)](http://example.com)
```

This PR is to fix this problem. 

Signed-off-by: Phus Lu <phuslu@hotmail.com>