### PR TITLE
Added "title" attr support to <img>

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -485,7 +485,8 @@ class HTML2Text(HTMLParser.HTMLParser):
                     self.o("![" + escape_md(alt) + "]")
                     if self.inline_links:
                         href = attrs.get('href') or ''
-                        self.o("(" + escape_md(urlparse.urljoin(self.baseurl, href)) + ")")
+                        title = attrs.get('title') or ''
+                        self.o("(" + escape_md(urlparse.urljoin(self.baseurl, href)) + (" \"{}\"".format(title) if title else "") + ")")
                     else:
                         i = self.previousIndex(attrs)
                         if i is not None:


### PR DESCRIPTION
I've added "title" attribute support for <img> tags as described [here](http://markdown-guide.readthedocs.io/en/latest/basics.html)

Also it is supported by at least python-markdown2. 
Feel free to merge it if you want to.