### PR TITLE
Error when empty title on <a> tag

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Etienne Millon <me@emillon.org>
 * John C F <gh: critiqjo>
 * Mikhail Melnik <by.zumzoom@gmail.com>
+* Andres Rey
 
 
 Maintainer:

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,6 +3,7 @@
 ----
 
 * Fix #157: Fix images link with div wrap
+* Fix #55: Fix error when empty title tags
 
 
 2016.9.19

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -427,7 +427,10 @@ class HTML2Text(HTMLParser.HTMLParser):
                             self.maybe_automatic_link = None
                         if self.inline_links:
                             try:
-                                title = escape_md(a['title'])
+                                if a['title'] is not None:
+                                    title = escape_md(a['title'])
+                                else:
+                                    title = ""
                             except KeyError:
                                 self.o("](" + escape_md(urlparse.urljoin(self.baseurl, a['href'])) + ")")
                             else:

--- a/test/empty-title-tag.html
+++ b/test/empty-title-tag.html
@@ -1,0 +1,1 @@
+<a href="test.html" title>This is an A tag with an empty title property</a>

--- a/test/empty-title-tag.md
+++ b/test/empty-title-tag.md
@@ -1,0 +1,2 @@
+[This is an A tag with an empty title property](test.html "" )
+


### PR DESCRIPTION
This fixes issue #155 

Checks if title is none. If so, assigns an empty string to the title. Otherwise passes the title to the escape_md function.