### PR TITLE
Fix tests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ The AUTHORS/Contributors are (and/or have been):
 * John C F <gh: critiqjo>
 * Mikhail Melnik <by.zumzoom@gmail.com>
 * Andres Rey
+* Ciprian Miclaus
 
 
 Maintainer:

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,7 @@
 
 * Fix #157: Fix images link with div wrap
 * Fix #55: Fix error when empty title tags
+* Fix #160: The html2text tests are failing on Windows and on Cygwin due to differences in eol handling between windows/*nix
 
 
 2016.9.19

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -660,7 +660,7 @@ class HTML2Text(HTMLParser.HTMLParser):
 
             if self.startpre:
                 #self.out(" :") #TODO: not output when already one there
-                if not data.startswith("\n"):  # <pre>stuff...
+                if not data.startswith("\n") and not data.startswith("\r\n"):  # <pre>stuff...
                     data = "\n" + data
                 if self.mark_code:
                     self.out("\n[code]")

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -17,6 +17,15 @@ logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
 import html2text
 
 
+def cleanup_eol(clean_str):
+    if os.name == 'nt' or sys.platform == 'cygwin':
+        # Fix the unwanted CR to CRCRLF replacement
+        # during text pipelining on Windows/cygwin
+        # on cygwin, os.name == 'posix', not nt
+        clean_str = re.sub(r'\r+', '\r', clean_str)
+        clean_str = clean_str.replace('\r\n', '\n')
+    return clean_str
+
 def test_module(fn, google_doc=False, **kwargs):
     h = html2text.HTML2Text()
     h.fn = fn
@@ -31,9 +40,9 @@ def test_module(fn, google_doc=False, **kwargs):
         setattr(h, k, v)
 
     result = get_baseline(fn)
-    inf = open(fn)
-    actual = h.handle(inf.read())
-    inf.close()
+    with open(fn) as inf:
+        actual = cleanup_eol(inf.read())
+        actual = h.handle(actual)
     return result, actual
 
 
@@ -56,11 +65,7 @@ def test_command(fn, *args):
 
     actual = out.decode('utf8')
 
-    if os.name == 'nt':
-        # Fix the unwanted CR to CRCRLF replacement
-        # during text pipelining on Windows/cygwin
-        actual = re.sub(r'\r+', '\r', actual)
-        actual = actual.replace('\r\n', '\n')
+    actual = cleanup_eol(actual)
 
     return result, actual
 
@@ -82,9 +87,10 @@ def get_baseline_name(fn):
 
 def get_baseline(fn):
     name = get_baseline_name(fn)
-    f = codecs.open(name, mode='r', encoding='utf8')
-    out = f.read()
-    f.close()
+    with codecs.open(name, mode='r', encoding='utf8') as f:
+        out = f.read()
+    #f.close()
+    out = cleanup_eol(out)
     return out
 
 

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -89,7 +89,6 @@ def get_baseline(fn):
     name = get_baseline_name(fn)
     with codecs.open(name, mode='r', encoding='utf8') as f:
         out = f.read()
-    #f.close()
     out = cleanup_eol(out)
     return out
 


### PR DESCRIPTION
This is a fix for #160: The html2text tests are failing on Windows and on Cygwin due to differences in eol handling between windows/*nix