### PR TITLE
Fix #143: Fix line wrapping for the lines starting with bold

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,7 +22,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Mikhail Melnik <by.zumzoom@gmail.com>
 * Andres Rey
 * Ciprian Miclaus
-
+* Toshihiro Kamiya <kamiya@mbj.nifty.com>
 
 Maintainer:
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,6 +7,7 @@
 * Fix #160: The html2text tests are failing on Windows and on Cygwin due to differences in eol handling between windows/*nix
 * Feature #164: Housekeeping: Add flake8 to the travis build, cleanup existing flake8 violations, add py3.6 and pypy3 to the travis build
 * Fix #109: Fix for unexpanded &lt; &gt; &amp;
+* Fix #143: Fix line wrapping for the lines starting with bold
 
 
 2016.9.19

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -190,7 +190,7 @@ def skipwrap(para, wrap_links):
     # I'm not sure what this is for; I thought it was to detect lists,
     # but there's a <br>-inside-<span> case in one of the tests that
     # also depends upon it.
-    if stripped[0:1] == '-' or stripped[0:1] == '*':
+    if stripped[0:1] == '-' or (stripped[0:1] == '*' and not stripped[0:2] == '**'):
         return True
 
     # If the text begins with a single -, *, or +, followed by a space,

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -190,7 +190,7 @@ def skipwrap(para, wrap_links):
     # I'm not sure what this is for; I thought it was to detect lists,
     # but there's a <br>-inside-<span> case in one of the tests that
     # also depends upon it.
-    if stripped[0:1] == '-' or (stripped[0:1] == '*' and not stripped[0:2] == '**'):
+    if stripped[0:1] in ('-', '*') and not stripped[0:2] == '**':
         return True
 
     # If the text begins with a single -, *, or +, followed by a space,

--- a/test/bold_long_line.html
+++ b/test/bold_long_line.html
@@ -1,0 +1,3 @@
+<p>
+<b>text</b> and a very long long long long long long long long long long long long long long long long long long long long line
+</p>

--- a/test/bold_long_line.md
+++ b/test/bold_long_line.md
@@ -1,0 +1,3 @@
+**text** and a very long long long long long long long long long long long
+long long long long long long long long long line
+


### PR DESCRIPTION
The cause #143 seems a line-wrapping function confusing itemize and bold.

This PR includes a fix of the function and the corresponding test case,
which was checked with CPython 3.5.3 on Ubuntu 17.04 amd 64.

I hope it will help.