### PR TITLE
adds support for "700" as indication that of bold text

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -223,7 +223,15 @@ class HTML2Text(HTMLParser.HTMLParser):
         # handle Google's text emphasis
         strikethrough = 'line-through' in \
                         tag_emphasis and self.hide_strikethrough
-        bold = 'bold' in tag_emphasis and 'bold' not in parent_emphasis
+
+        # google and others may mark a font's weight as `bold` or `700`
+        bold = False
+        for bold_marker in config.BOLD_TEXT_STYLE_VALUES:
+            bold = (bold_marker in tag_emphasis
+                    and bold_marker not in parent_emphasis)
+            if bold is True:
+                break
+
         italic = 'italic' in tag_emphasis and 'italic' not in parent_emphasis
         fixed = google_fixed_width_font(tag_style) and not \
             google_fixed_width_font(parent_style) and not self.pre

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -31,6 +31,9 @@ WRAP_LINKS = True
 # Number of pixels Google indents nested lists
 GOOGLE_LIST_INDENT = 36
 
+# Values Google and others may use to indicate bold text
+BOLD_TEXT_STYLE_VALUES = ('bold', '700')
+
 IGNORE_ANCHORS = False
 IGNORE_IMAGES = False
 IMAGES_TO_ALT = False

--- a/test/google-like_font-properties.html
+++ b/test/google-like_font-properties.html
@@ -5,6 +5,8 @@
   <BODY>
     <p><span style="font-weight: bold">font-weight: bold</span></p>
     <P><SPAN STYLE="FONT-WEIGHT: BOLD">FONT-WEIGHT: BOLD</SPAN></P>
+    <P><SPAN STYLE="font-weight: 700">font-weight: 700</SPAN></P>
+    <P><SPAN STYLE="FONT-WEIGHT: 700">FONT-WEIGHT: 700</SPAN></P>
     <p><span style="font-style: italic">font-style: italic</span></p>
     <P><SPAN STYLE="FONT-STYLE: ITALIC">FONT-STYLE: ITALIC</SPAN></P>
     <p><span style="font-weight: bold;font-style: italic">

--- a/test/google-like_font-properties.md
+++ b/test/google-like_font-properties.md
@@ -1,5 +1,7 @@
 **font-weight: bold**   
 **FONT-WEIGHT: BOLD**   
+**font-weight: 700**   
+**FONT-WEIGHT: 700**   
 _font-style: italic_   
 _FONT-STYLE: ITALIC_   
 _**font-weight: bold;font-style: italic**_   


### PR DESCRIPTION
google, and presumably others, use `font-weight: 700` to make bold a region of text.
this pr polls tag styles for both `bold` and `700` (via new config value,
`BOLD_TEXT_STYLE_VALUES`) to be certain.