### PR TITLE
Adds support for "700", "800", and "900" as bold style indicators

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Andres Rey
 * Ciprian Miclaus
 * Toshihiro Kamiya <kamiya@mbj.nifty.com>
+* Matt Dennewitz <mattdennewitz@gmail.com>
 
 Maintainer:
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -9,6 +9,12 @@
 * Fix #109: Fix for unexpanded &lt; &gt; &amp;
 * Fix #143: Fix line wrapping for the lines starting with bold
 
+2017.7.27
+=========
+----
+
+* Adds support for numeric bold text indication in `font-weight`,
+  as used by Google (and presumably others.)
 
 2016.9.19
 =========

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,13 +8,9 @@
 * Feature #164: Housekeeping: Add flake8 to the travis build, cleanup existing flake8 violations, add py3.6 and pypy3 to the travis build
 * Fix #109: Fix for unexpanded &lt; &gt; &amp;
 * Fix #143: Fix line wrapping for the lines starting with bold
-
-2017.7.27
-=========
-----
-
 * Adds support for numeric bold text indication in `font-weight`,
   as used by Google (and presumably others.)
+
 
 2016.9.19
 =========

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -223,7 +223,15 @@ class HTML2Text(HTMLParser.HTMLParser):
         # handle Google's text emphasis
         strikethrough = 'line-through' in \
                         tag_emphasis and self.hide_strikethrough
-        bold = 'bold' in tag_emphasis and 'bold' not in parent_emphasis
+
+        # google and others may mark a font's weight as `bold` or `700`
+        bold = False
+        for bold_marker in config.BOLD_TEXT_STYLE_VALUES:
+            bold = (bold_marker in tag_emphasis
+                    and bold_marker not in parent_emphasis)
+            if bold is True:
+                break
+
         italic = 'italic' in tag_emphasis and 'italic' not in parent_emphasis
         fixed = google_fixed_width_font(tag_style) and not \
             google_fixed_width_font(parent_style) and not self.pre

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -229,7 +229,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         for bold_marker in config.BOLD_TEXT_STYLE_VALUES:
             bold = (bold_marker in tag_emphasis
                     and bold_marker not in parent_emphasis)
-            if bold is True:
+            if bold:
                 break
 
         italic = 'italic' in tag_emphasis and 'italic' not in parent_emphasis

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -31,6 +31,9 @@ WRAP_LINKS = True
 # Number of pixels Google indents nested lists
 GOOGLE_LIST_INDENT = 36
 
+# Values Google and others may use to indicate bold text
+BOLD_TEXT_STYLE_VALUES = ('bold', '700', '800', '900')
+
 IGNORE_ANCHORS = False
 IGNORE_IMAGES = False
 IMAGES_TO_ALT = False

--- a/test/google-like_font-properties.html
+++ b/test/google-like_font-properties.html
@@ -5,6 +5,12 @@
   <BODY>
     <p><span style="font-weight: bold">font-weight: bold</span></p>
     <P><SPAN STYLE="FONT-WEIGHT: BOLD">FONT-WEIGHT: BOLD</SPAN></P>
+    <P><SPAN STYLE="font-weight: 700">font-weight: 700</SPAN></P>
+    <P><SPAN STYLE="FONT-WEIGHT: 700">FONT-WEIGHT: 700</SPAN></P>
+    <P><SPAN STYLE="font-weight: 800">font-weight: 800</SPAN></P>
+    <P><SPAN STYLE="FONT-WEIGHT: 800">FONT-WEIGHT: 800</SPAN></P>
+    <P><SPAN STYLE="font-weight: 900">font-weight: 900</SPAN></P>
+    <P><SPAN STYLE="FONT-WEIGHT: 900">FONT-WEIGHT: 900</SPAN></P>
     <p><span style="font-style: italic">font-style: italic</span></p>
     <P><SPAN STYLE="FONT-STYLE: ITALIC">FONT-STYLE: ITALIC</SPAN></P>
     <p><span style="font-weight: bold;font-style: italic">

--- a/test/google-like_font-properties.md
+++ b/test/google-like_font-properties.md
@@ -1,5 +1,11 @@
 **font-weight: bold**   
 **FONT-WEIGHT: BOLD**   
+**font-weight: 700**   
+**FONT-WEIGHT: 700**   
+**font-weight: 800**   
+**FONT-WEIGHT: 800**   
+**font-weight: 900**   
+**FONT-WEIGHT: 900**   
 _font-style: italic_   
 _FONT-STYLE: ITALIC_   
 _**font-weight: bold;font-style: italic**_   


### PR DESCRIPTION
Google, and presumably others, use `font-weight: 700` to make bold a region of text.
This PR polls tag styles for both `bold` and `700` through `900` (via new config value,
`BOLD_TEXT_STYLE_VALUES`) before declaring text as bold or regular.