### PR TITLE
Refactor imports and title for links

### DIFF
--- a/test/empty-title-tag.md
+++ b/test/empty-title-tag.md
@@ -1,2 +1,2 @@
-[This is an A tag with an empty title property](test.html "" )
+[This is an A tag with an empty title property](test.html)
 

--- a/test/link_titles.md
+++ b/test/link_titles.md
@@ -1,3 +1,3 @@
-[ first example](http://example.com "MyTitle" )  
+[ first example](http://example.com "MyTitle")  
 [ second example](http://example.com)
 


### PR DESCRIPTION
This cleans up the discrepancies between python3 and python2 functions a bit as well as refactoring a very unreadable way of how the title is being handled for links. 