### PR TITLE
Don't delete cells from tables with non-equal row lengths (e.g. using `colspan` attribute)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Toshihiro Kamiya <kamiya@mbj.nifty.com>
 * Matt Dennewitz <mattdennewitz@gmail.com>
 * Jonathan Sundqvist <sundqvist.jonathan@gmail.com>
+* Simon Meers <gh: DrMeers>
 
 Maintainer:
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -11,6 +11,7 @@
 * Adds support for numeric bold text indication in `font-weight`,
   as used by Google (and presumably others.)
 * Fix #173 and #142: Stripping whitespace in crucial markdown and adding whitespace as necessary
+* Don't drop any cell data on tables uneven row lengths (e.g. colspan in use)
 
 
 2016.9.19

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -254,6 +254,16 @@ def reformat_table(lines, right_margin):
     max_width = [len(x.rstrip()) + right_margin for x in lines[0].split('|')]
     for line in lines:
         cols = [x.rstrip() for x in line.split('|')]
+
+        # don't drop any data if colspan attributes result in unequal lengths
+        if len(cols) < len(max_width):
+            cols += [''] * (len(max_width) - len(cols))
+        elif len(max_width) < len(cols):
+            max_width += [
+                len(x) + right_margin for x in
+                cols[-(len(cols) - len(max_width)):]
+            ]
+
         max_width = [max(len(x) + right_margin, old_len)
                      for x, old_len in zip(cols, max_width)]
 

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -252,17 +252,20 @@ def reformat_table(lines, right_margin):
     """
     # find the maximum width of the columns
     max_width = [len(x.rstrip()) + right_margin for x in lines[0].split('|')]
+    max_cols = len(max_width)
     for line in lines:
         cols = [x.rstrip() for x in line.split('|')]
+        num_cols = len(cols)
 
         # don't drop any data if colspan attributes result in unequal lengths
-        if len(cols) < len(max_width):
-            cols += [''] * (len(max_width) - len(cols))
-        elif len(max_width) < len(cols):
+        if num_cols < max_cols:
+            cols += [''] * (max_cols - num_cols)
+        elif max_cols < num_cols:
             max_width += [
                 len(x) + right_margin for x in
-                cols[-(len(cols) - len(max_width)):]
+                cols[-(num_cols - max_cols):]
             ]
+            max_cols = num_cols
 
         max_width = [max(len(x) + right_margin, old_len)
                      for x, old_len in zip(cols, max_width)]

--- a/test/pad_table.html
+++ b/test/pad_table.html
@@ -36,4 +36,16 @@ something else entirely<br>
       </tbody>
     </table>
 
+    <table>
+      <thead>
+        <tr><th colspan="2">One+Two</th><th>Three</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>A</td><td>B</td><th>C</th></tr>
+        <tr><td>A</td><td colspan="2">B+C</td></tr>
+        <tr><td colspan="2">A+B</td><td>C</td></tr>
+        <tr><td colspan="3">A+B+C</td></tr>
+      </tbody>
+    </table>
+
 </body> </html>

--- a/test/pad_table.html
+++ b/test/pad_table.html
@@ -22,5 +22,18 @@ some content between the tables<br>
         <tr> <td>Content 1</td> <td>Content 2 longer</td> <td><img src="http://lorempixel.com/200/200" alt="200"/> Image!</td> </tr>
     </table>
 
-something else entirely
+something else entirely<br>
+
+    <table>
+      <thead>
+        <tr><th>One</th><th>Two</th><th>Three</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>A</td><td>B</td><th>C</th></tr>
+        <tr><td>A</td><td colspan="2">B+C</td></tr>
+        <tr><td colspan="2">A+B</td><td>C</td></tr>
+        <tr><td colspan="3">A+B+C</td></tr>
+      </tbody>
+    </table>
+
 </body> </html>

--- a/test/pad_table.md
+++ b/test/pad_table.md
@@ -24,5 +24,12 @@ Header 1  | Header 2         | Header 3
 Content 1 | Content 2        | ![200](http://lorempixel.com/200/200) Image! 
 Content 1 | Content 2 longer | ![200](http://lorempixel.com/200/200) Image! 
 
-something else entirely
+something else entirely  
+One   | Two | Three 
+------|-----|-------
+A     | B   | C     
+A     | B+C 
+A+B   | C   
+A+B+C 
+
 

--- a/test/pad_table.md
+++ b/test/pad_table.md
@@ -32,4 +32,11 @@ A     | B+C
 A+B   | C   
 A+B+C 
 
+One+Two | Three 
+--------|-------
+A       | B     | C 
+A       | B+C   
+A+B     | C     
+A+B+C   
+
 


### PR DESCRIPTION
Current implementation simply drops cells until all rows have the lowest common length