### PR TITLE
Adding flag for escaping surrogate

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,6 +30,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Germain Z. <gh: GermainZ>
 * Jacek Kołodziej <kolodziejj@gmail.com>
 * Jonathan Vanasco <jonathan@findmeon.com>
+* Mohiuddin Ahmed <ahmed.mohi.duet@gmail.com>
 
 Maintainer:
 

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -515,8 +515,8 @@ class HTML2Text(HTMLParser.HTMLParser):
 
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
-                if self.images_as_html or (self.images_with_size and 
-                    ("width" in attrs or "height" in attrs)):
+                if self.images_as_html or (self.images_with_size and (
+                    "width" in attrs or "height" in attrs)):
                     self.o("<img src='" + attrs["src"] + "' ")
                     if "width" in attrs:
                         self.o("width='" + attrs["width"] + "' ")

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -516,7 +516,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
                 if self.images_as_html or (self.images_with_size and (
-                    "width" in attrs or "height" in attrs)):
+                "width" in attrs or "height" in attrs)):
                     self.o("<img src='" + attrs["src"] + "' ")
                     if "width" in attrs:
                         self.o("width='" + attrs["width"] + "' ")

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -78,6 +78,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.ignore_emphasis = config.IGNORE_EMPHASIS  # covered in cli
         self.bypass_tables = config.BYPASS_TABLES  # covered in cli
         self.ignore_tables = config.IGNORE_TABLES  # covered in cli
+        self.surrogate_escape = config.SURROGATE_ESCAPE
         self.google_doc = False  # covered in cli
         self.ul_item_mark = '*'  # covered in cli
         self.emphasis_mark = '_'  # covered in cli

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -515,8 +515,8 @@ class HTML2Text(HTMLParser.HTMLParser):
 
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
-                if self.images_as_html or (self.images_with_size and \
-                        ("width" in attrs or "height" in attrs)):
+                if self.images_as_html or (self.images_with_size and 
+                    ("width" in attrs or "height" in attrs)):
                     self.o("<img src='" + attrs["src"] + "' ")
                     if "width" in attrs:
                         self.o("width='" + attrs["width"] + "' ")

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -516,16 +516,16 @@ class HTML2Text(HTMLParser.HTMLParser):
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
                 if self.images_as_html or (self.images_with_size and (
-                "width" in attrs or "height" in attrs)):
-                    self.o("<img src='" + attrs["src"] + "' ")
-                    if "width" in attrs:
-                        self.o("width='" + attrs["width"] + "' ")
-                    if "height" in attrs:
-                        self.o("height='" + attrs["height"] + "' ")
-                    if alt:
-                        self.o("alt='" + alt + "' ")
-                    self.o("/>")
-                    return
+                    "width" in attrs or "height" in attrs)):
+                        self.o("<img src='" + attrs["src"] + "' ")
+                        if "width" in attrs:
+                            self.o("width='" + attrs["width"] + "' ")
+                        if "height" in attrs:
+                            self.o("height='" + attrs["height"] + "' ")
+                        if alt:
+                            self.o("alt='" + alt + "' ")
+                        self.o("/>")
+                        return
 
                 # If we have a link to create, output the start
                 if self.maybe_automatic_link is not None:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -515,17 +515,23 @@ class HTML2Text(HTMLParser.HTMLParser):
 
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
-                if self.images_as_html or (self.images_with_size and (
-                    "width" in attrs or "height" in attrs)):
-                            self.o("<img src='" + attrs["src"] + "' ")
-                            if "width" in attrs:
-                                self.o("width='" + attrs["width"] + "' ")
-                            if "height" in attrs:
-                                self.o("height='" + attrs["height"] + "' ")
-                            if alt:
-                                self.o("alt='" + alt + "' ")
-                            self.o("/>")
-                            return
+                if self.images_as_html or (
+                                           self.images_with_size and (
+                                                                      "width"
+                                                                      in attrs
+                                                                      or
+                                                                      "height"
+                                                                      in
+                                                                      attrs)):
+                    self.o("<img src='" + attrs["src"] + "' ")
+                    if "width" in attrs:
+                        self.o("width='" + attrs["width"] + "' ")
+                    if "height" in attrs:
+                        self.o("height='" + attrs["height"] + "' ")
+                    if alt:
+                        self.o("alt='" + alt + "' ")
+                    self.o("/>")
+                    return
 
                 # If we have a link to create, output the start
                 if self.maybe_automatic_link is not None:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -517,15 +517,15 @@ class HTML2Text(HTMLParser.HTMLParser):
                 # height, and alt attributes
                 if self.images_as_html or (self.images_with_size and (
                     "width" in attrs or "height" in attrs)):
-                        self.o("<img src='" + attrs["src"] + "' ")
-                        if "width" in attrs:
-                            self.o("width='" + attrs["width"] + "' ")
-                        if "height" in attrs:
-                            self.o("height='" + attrs["height"] + "' ")
-                        if alt:
-                            self.o("alt='" + alt + "' ")
-                        self.o("/>")
-                        return
+                            self.o("<img src='" + attrs["src"] + "' ")
+                            if "width" in attrs:
+                                self.o("width='" + attrs["width"] + "' ")
+                            if "height" in attrs:
+                                self.o("height='" + attrs["height"] + "' ")
+                            if alt:
+                                self.o("alt='" + alt + "' ")
+                            self.o("/>")
+                            return
 
                 # If we have a link to create, output the start
                 if self.maybe_automatic_link is not None:

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -90,7 +90,8 @@ def main():
         dest="images_as_html",
         action="store_true",
         default=config.IMAGES_AS_HTML,
-        help="Always write image tags as raw html; preserves `height`, `width` "
+        help="Always write image tags as raw html; "
+             "preserves `height`, `width` "
              "and `alt` if possible."
     )
     p.add_option(

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -101,6 +101,14 @@ def main():
         help="Discard image data, only keep alt text"
     )
     p.add_option(
+        "--surrogate-escape",
+        dest="surrogate_escape",
+        action="store_true",
+        default=config.SURROGATE_ESCAPE,
+        help="Escaping some special characters and avoid error "
+             "during printing in console"
+    )
+    p.add_option(
         "--images-with-size",
         dest="images_with_size",
         action="store_true",
@@ -320,6 +328,7 @@ def main():
     h.escape_snob = options.escape_snob
     h.bypass_tables = options.bypass_tables
     h.ignore_tables = options.ignore_tables
+    h.surrogate_escape = options.surrogate_escape
     h.single_line_break = options.single_line_break
     h.inline_links = options.inline_links
     h.unicode_snob = options.unicode_snob
@@ -334,4 +343,7 @@ def main():
     h.open_quote = options.open_quote
     h.close_quote = options.close_quote
 
-    wrapwrite(h.handle(data))
+    if options.surrogate_escape:
+        wrapwrite(h.handle(data), errors='surrogateescape')
+    else:
+        wrapwrite(h.handle(data))

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -49,6 +49,7 @@ MARK_CODE = False
 DECODE_ERRORS = 'strict'
 DEFAULT_IMAGE_ALT = ''
 PAD_TABLES = False
+SURROGATE_ESCAPE = False
 
 # Convert links with same href and text to <href> format
 # if they are absolute links

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -202,9 +202,9 @@ def skipwrap(para, wrap_links, wrap_list_items):
 
     return False
 
+def wrapwrite(text, errors='strict'):
+    text = text.encode('utf-8', errors)
 
-def wrapwrite(text):
-    text = text.encode('utf-8')
     try:  # Python3
         sys.stdout.buffer.write(text)
     except AttributeError:

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -202,6 +202,7 @@ def skipwrap(para, wrap_links, wrap_list_items):
 
     return False
 
+
 def wrapwrite(text, errors='strict'):
     text = text.encode('utf-8', errors)
 

--- a/test/surrogate_escape.html
+++ b/test/surrogate_escape.html
@@ -1,0 +1,2 @@
+<a class="dropdown--item_anchor transition--background" href="/learn-spring-security-course" title="The “Learn Spring Security” Course">
+</a>

--- a/test/surrogate_escape.md
+++ b/test/surrogate_escape.md
@@ -1,0 +1,2 @@
+[ ](/learn-spring-security-course "The “Learn Spring Security” Course")
+

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -90,7 +90,7 @@ def get_baseline(fn):
     name = get_baseline_name(fn)
     with codecs.open(name, mode='r', encoding='utf8',
         errors='surrogateescape') as f:
-            out = f.read()
+                out = f.read()
     out = cleanup_eol(out)
     return out
 

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -89,8 +89,8 @@ def get_baseline_name(fn):
 def get_baseline(fn):
     name = get_baseline_name(fn)
     with codecs.open(name, mode='r', encoding='utf8',
-    errors='surrogateescape') as f:
-        out = f.read()
+        errors='surrogateescape') as f:
+            out = f.read()
     out = cleanup_eol(out)
     return out
 

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -89,7 +89,7 @@ def get_baseline_name(fn):
 def get_baseline(fn):
     name = get_baseline_name(fn)
     with codecs.open(name, mode='r', encoding='utf8',
-        errors='surrogateescape') as f:
+    errors='surrogateescape') as f:
         out = f.read()
     out = cleanup_eol(out)
     return out

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -89,7 +89,7 @@ def get_baseline_name(fn):
 def get_baseline(fn):
     name = get_baseline_name(fn)
     with codecs.open(
-			name, mode='r', encoding='utf8',errors='surrogateescape') as f:
+        name, mode='r', encoding='utf8',errors='surrogateescape') as f:
         out = f.read()
     out = cleanup_eol(out)
     return out

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -89,7 +89,7 @@ def get_baseline_name(fn):
 def get_baseline(fn):
     name = get_baseline_name(fn)
     with codecs.open(name, mode='r', encoding='utf8',
-	    errors='surrogateescape') as f:
+        errors='surrogateescape') as f:
         out = f.read()
     out = cleanup_eol(out)
     return out

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -88,8 +88,8 @@ def get_baseline_name(fn):
 
 def get_baseline(fn):
     name = get_baseline_name(fn)
-    with codecs.open(
-        name, mode='r', encoding='utf8',errors='surrogateescape') as f:
+    with codecs.open(name, mode='r', encoding='utf8',
+	    errors='surrogateescape') as f:
         out = f.read()
     out = cleanup_eol(out)
     return out

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -41,7 +41,7 @@ def test_module(fn, google_doc=False, **kwargs):
         setattr(h, k, v)
 
     result = get_baseline(fn)
-    with open(fn) as inf:
+    with codecs.open(fn, encoding='utf-8') as inf:
         actual = cleanup_eol(inf.read())
         actual = h.handle(actual)
     return result, actual
@@ -88,7 +88,8 @@ def get_baseline_name(fn):
 
 def get_baseline(fn):
     name = get_baseline_name(fn)
-    with codecs.open(name, mode='r', encoding='utf8') as f:
+    with codecs.open(
+			name, mode='r', encoding='utf8',errors='surrogateescape') as f:
         out = f.read()
     out = cleanup_eol(out)
     return out
@@ -185,6 +186,10 @@ def generate_test(fn):
         module_args['body_width'] = 0
         cmdline_args.append('--body-width=0')
         func_args['bodywidth'] = 0
+
+    if base_fn.startswith('surrogate_escape'):
+        module_args['surrogate_escape'] = True
+        cmdline_args.append('--surrogate-escape')
 
     if base_fn.startswith('protect_links'):
         module_args['protect_links'] = True

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -88,9 +88,10 @@ def get_baseline_name(fn):
 
 def get_baseline(fn):
     name = get_baseline_name(fn)
-    with codecs.open(name, mode='r', encoding='utf8',
-        errors='surrogateescape') as f:
-                out = f.read()
+    with codecs.open(
+                     name, mode='r', encoding='utf8',
+                     errors='surrogateescape') as f:
+        out = f.read()
     out = cleanup_eol(out)
     return out
 


### PR DESCRIPTION
Throwing errors for my command:

curl http://www.baeldung.com/websockets-spring|html2text|vim -

Traceback (most recent call last):
File "C:\Users\mohi\AppData\Local\Programs\Python\Python36\Scripts\html2text-script.py", line 11, in 
load_entry_point('html2text==2017.10.4', 'console_scripts', 'html2text')()
File "c:\users\mohi\appdata\local\programs\python\python36\lib\site-packages\html2text\cli.py", line 306, in main
wrapwrite(h.handle(data))
File "c:\users\mohi\appdata\local\programs\python\python36\lib\site-packages\html2text\utils.py", line 207, in wrapwrite
text = text.encode('utf-8')
UnicodeEncodeError: 'utf-8' codec can't encode character '\udc9d' in position 676: surrogates not allowed