### PR TITLE
Drop support for EOL Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,22 @@
+dist: xenial
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "pypy"
-  - "pypy3"
-  # - "3.2"  # Cython needs Python 2.6+ or 3.3+
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-before_install:
-  # Python 3.2 needs setuptools < 30 - support for Py3.2 was dropped after that version
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then pip install -U 'setuptools<30'; fi
+  - "3.7"
+  - "pypy2.7-6.0"
+  - "pypy3.5-6.0"
 install:
-    - pip install coveralls==0.5
+  - pip install coveralls
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
-  # flake8 doesn't support Python 2.6
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install flake8==3.3.0;flake8 .; fi
+  - pip install flake8
+  - flake8
   - export COVERAGE_PROCESS_START=$PWD/.coveragerc
 script:
-  - PYTHONPATH=$PYTHONPATH:. coverage run --source=html2text --rcfile=.coveragerc setup.py test -v
+  - coverage run --source=html2text setup.py test
   - coverage combine
   - coverage report
 after_success:
-    coveralls --rcfile=.coveragerc
+    coveralls

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@
 * Add support for wrapping list items.
 * Fix #201: handle &lrm;/&rlm; marks mid-text within stressed tags or right after stressed tags.
 * Feature #213: `images_as_html` config option to always generate an `img` html tag. preserves "height", "width" and "alt" if possible.
+* Remove support for end-of-life Pythons. Now requires Python 2.7 or 3.4+.
 
 2018.9.1
 ========

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ $ pip install html2text
 
 ## How to run unit tests
 
-    PYTHONPATH=$PYTHONPATH:. coverage run --source=html2text setup.py test -v
+    coverage run --source=html2text setup.py test
 
 To see the coverage results:
-    
+
     coverage combine
     coverage html
 

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -514,8 +514,10 @@ class HTML2Text(HTMLParser.HTMLParser):
 
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
-                if self.images_as_html or (self.images_with_size and \
-                        ("width" in attrs or "height" in attrs)):
+                if self.images_as_html or (
+                        self.images_with_size and
+                        ("width" in attrs or "height" in attrs)
+                ):
                     self.o("<img src='" + attrs["src"] + "' ")
                     if "width" in attrs:
                         self.o("width='" + attrs["width"] + "' ")

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -5,11 +5,7 @@ from __future__ import division
 from __future__ import unicode_literals
 import re
 import sys
-
-try:
-    from textwrap import wrap
-except ImportError:  # pragma: no cover
-    pass
+from textwrap import wrap
 
 from html2text.compat import urlparse, HTMLParser
 from html2text import config
@@ -460,7 +456,7 @@ class HTML2Text(HTMLParser.HTMLParser):
 
         def link_url(self, link, title=""):
             url = urlparse.urljoin(self.baseurl, link)
-            title = ' "{0}"'.format(title) if title.strip() else ''
+            title = ' "{}"'.format(title) if title.strip() else ''
             self.o(']({url}{title})'.format(url=escape_md(url),
                                             title=title))
 
@@ -637,14 +633,14 @@ class HTML2Text(HTMLParser.HTMLParser):
                     self.soft_br()
                 if tag in ["td", "th"]:
                     if start:
-                        self.o('<{0}>\n\n'.format(tag))
+                        self.o('<{}>\n\n'.format(tag))
                     else:
-                        self.o('\n</{0}>'.format(tag))
+                        self.o('\n</{}>'.format(tag))
                 else:
                     if start:
-                        self.o('<{0}>'.format(tag))
+                        self.o('<{}>'.format(tag))
                     else:
-                        self.o('</{0}>'.format(tag))
+                        self.o('</{}>'.format(tag))
 
             else:
                 if tag == "table":
@@ -849,7 +845,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         else:
             c = int(name)
 
-        if not self.unicode_snob and c in unifiable_n.keys():
+        if not self.unicode_snob and c in unifiable_n:
             return unifiable_n[c]
         else:
             try:
@@ -858,7 +854,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                 return ''
 
     def entityref(self, c):
-        if not self.unicode_snob and c in config.UNIFIABLE.keys():
+        if not self.unicode_snob and c in config.UNIFIABLE:
             return config.UNIFIABLE[c]
         else:
             try:
@@ -907,7 +903,6 @@ class HTML2Text(HTMLParser.HTMLParser):
         if not self.body_width:
             return text
 
-        assert wrap, "Requires Python 2.3."
         result = ''
         newlines = 0
         # I cannot think of a better solution for now.

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -1,4 +1,4 @@
-import optparse
+import argparse
 import warnings
 
 from html2text.compat import urllib
@@ -19,73 +19,68 @@ def main():
         BOLD = '\033[1m'
         UNDERLINE = '\033[4m'
 
-    p = optparse.OptionParser(
-        '%prog [(filename|url) [encoding]]',
-        version='%prog ' + ".".join(map(str, __version__))
-    )
-    p.add_option(
+    p = argparse.ArgumentParser()
+    p.add_argument(
         "--default-image-alt",
         dest="default_image_alt",
-        action="store",
-        type="str",
         default=config.DEFAULT_IMAGE_ALT,
         help="The default alt string for images with missing ones")
-    p.add_option(
+    p.add_argument(
         "--pad-tables",
         dest="pad_tables",
         action="store_true",
         default=config.PAD_TABLES,
         help="pad the cells to equal column width in tables"
     )
-    p.add_option(
+    p.add_argument(
         "--no-wrap-links",
         dest="wrap_links",
         action="store_false",
         default=config.WRAP_LINKS,
         help="wrap links during conversion"
     )
-    p.add_option(
+    p.add_argument(
         "--wrap-list-items",
         dest="wrap_list_items",
         action="store_true",
         default=config.WRAP_LIST_ITEMS,
         help="wrap list items during conversion"
     )
-    p.add_option(
+    p.add_argument(
         "--ignore-emphasis",
         dest="ignore_emphasis",
         action="store_true",
         default=config.IGNORE_EMPHASIS,
         help="don't include any formatting for emphasis"
     )
-    p.add_option(
+    p.add_argument(
         "--reference-links",
         dest="inline_links",
         action="store_false",
         default=config.INLINE_LINKS,
         help="use reference style links instead of inline links"
     )
-    p.add_option(
+    p.add_argument(
         "--ignore-links",
         dest="ignore_links",
         action="store_true",
         default=config.IGNORE_ANCHORS,
         help="don't include any formatting for links")
-    p.add_option(
+    p.add_argument(
         "--protect-links",
         dest="protect_links",
         action="store_true",
         default=config.PROTECT_LINKS,
         help=("protect links from line breaks surrounding them " +
               "with angle brackets"))
-    p.add_option(
+    p.add_argument(
         "--ignore-images",
         dest="ignore_images",
         action="store_true",
         default=config.IGNORE_IMAGES,
         help="don't include any formatting for images"
     )
-    p.add_option(
+    p.add_argument(
         "--images-as-html",
         dest="images_as_html",
         action="store_true",
@@ -95,14 +90,14 @@ def main():
             "and `alt` if possible."
         )
     )
-    p.add_option(
+    p.add_argument(
         "--images-to-alt",
         dest="images_to_alt",
         action="store_true",
         default=config.IMAGES_TO_ALT,
         help="Discard image data, only keep alt text"
     )
-    p.add_option(
+    p.add_argument(
         "--images-with-size",
         dest="images_with_size",
         action="store_true",
@@ -110,44 +105,42 @@ def main():
         help="Write image tags with height and width attrs as raw html to "
              "retain dimensions"
     )
-    p.add_option(
+    p.add_argument(
         "-g", "--google-doc",
         action="store_true",
         dest="google_doc",
         default=False,
         help="convert an html-exported Google Document"
     )
-    p.add_option(
+    p.add_argument(
         "-d", "--dash-unordered-list",
         action="store_true",
         dest="ul_style_dash",
         default=False,
         help="use a dash rather than a star for unordered list items"
     )
-    p.add_option(
+    p.add_argument(
         "-e", "--asterisk-emphasis",
         action="store_true",
         dest="em_style_asterisk",
         default=False,
         help="use an asterisk rather than an underscore for emphasized text"
     )
-    p.add_option(
+    p.add_argument(
         "-b", "--body-width",
         dest="body_width",
-        action="store",
-        type="int",
+        type=int,
         default=config.BODY_WIDTH,
         help="number of characters per output line, 0 for no wrap"
     )
-    p.add_option(
+    p.add_argument(
         "-i", "--google-list-indent",
         dest="list_indent",
-        action="store",
-        type="int",
+        type=int,
         default=config.GOOGLE_LIST_INDENT,
         help="number of pixels Google indents nested lists"
     )
-    p.add_option(
+    p.add_argument(
         "-s", "--hide-strikethrough",
         action="store_true",
         dest="hide_strikethrough",
@@ -155,7 +148,7 @@ def main():
         help="hide strike-through text. only relevant when -g is "
              "specified as well"
     )
-    p.add_option(
+    p.add_argument(
         "--escape-all",
         action="store_true",
         dest="escape_snob",
@@ -163,14 +156,14 @@ def main():
         help="Escape all special characters.  Output is less readable, but "
              "avoids corner case formatting issues."
     )
-    p.add_option(
+    p.add_argument(
         "--bypass-tables",
         action="store_true",
         dest="bypass_tables",
         default=config.BYPASS_TABLES,
         help="Format tables in HTML rather than Markdown syntax."
     )
-    p.add_option(
+    p.add_argument(
         "--ignore-tables",
         action="store_true",
         dest="ignore_tables",
@@ -178,7 +171,7 @@ def main():
         help="Ignore table-related tags (table, th, td, tr) "
              "while keeping rows."
     )
-    p.add_option(
+    p.add_argument(
         "--single-line-break",
         action="store_true",
         dest="single_line_break",
@@ -188,152 +181,129 @@ def main():
             "line breaks. NOTE: Requires --body-width=0"
         )
     )
-    p.add_option(
+    p.add_argument(
         "--unicode-snob",
         action="store_true",
         dest="unicode_snob",
         default=config.UNICODE_SNOB,
         help="Use unicode throughout document"
     )
-    p.add_option(
+    p.add_argument(
         "--no-automatic-links",
         action="store_false",
         dest="use_automatic_links",
         default=config.USE_AUTOMATIC_LINKS,
         help="Do not use automatic links wherever applicable"
     )
-    p.add_option(
+    p.add_argument(
         "--no-skip-internal-links",
         action="store_false",
         dest="skip_internal_links",
         default=config.SKIP_INTERNAL_LINKS,
         help="Do not skip internal links"
     )
-    p.add_option(
+    p.add_argument(
         "--links-after-para",
         action="store_true",
         dest="links_each_paragraph",
         default=config.LINKS_EACH_PARAGRAPH,
         help="Put links after each paragraph instead of document"
     )
-    p.add_option(
+    p.add_argument(
         "--mark-code",
         action="store_true",
         dest="mark_code",
         default=config.MARK_CODE,
         help="Mark program code blocks with [code]...[/code]"
     )
-    p.add_option(
+    p.add_argument(
         "--decode-errors",
         dest="decode_errors",
-        action="store",
-        type="string",
         default=config.DECODE_ERRORS,
         help="What to do in case of decode errors.'ignore', 'strict' and "
              "'replace' are acceptable values"
     )
-    p.add_option(
+    p.add_argument(
         "--open-quote",
         dest="open_quote",
-        action="store",
-        type="str",
         default=config.OPEN_QUOTE,
         help="The character used to open quotes",
     )
-    p.add_option(
+    p.add_argument(
         "--close-quote",
         dest="close_quote",
-        action="store",
-        type="str",
         default=config.CLOSE_QUOTE,
         help="The character used to close quotes",
     )
-    (options, args) = p.parse_args()
+    p.add_argument(
+        '--version',
+        action='version',
+        version='.'.join(map(str, __version__))
+    )
+    p.add_argument('filename', nargs='?')
+    p.add_argument('encoding', nargs='?', default='utf-8')
+    args = p.parse_args()
 
-    # process input
-    encoding = "utf-8"
-    if len(args) == 2:
-        encoding = args[1]
-    elif len(args) > 2:
-        p.error('Too many arguments')
-
-    if len(args) > 0 and args[0] != '-':  # pragma: no cover
-        file_ = args[0]
-
-        if file_.startswith('http://') or file_.startswith('https://'):
+    if args.filename and args.filename != '-':  # pragma: no cover
+        if (args.filename.startswith('http://') or
+                args.filename.startswith('https://')):
             warnings.warn(
                 "Support for retrieving html over network is set for "
                 "deprecation by version (2017, 1, x)",
                 DeprecationWarning
             )
-            baseurl = file_
+            baseurl = args.filename
             j = urllib.urlopen(baseurl)
             data = j.read()
-            if encoding is None:
-                try:
-                    from feedparser import _getCharacterEncoding as enc
-                except ImportError:
-                    def enc(x, y):
-                        return ('utf-8', 1)
-                encoding = enc(j.headers, data)[0]
-                if encoding == 'us-ascii':
-                    encoding = 'utf-8'
         else:
-            data = open(file_, 'rb').read()
-            if encoding is None:
-                try:
-                    from chardet import detect
-                except ImportError:
-                    def detect(x):
-                        return {'encoding': 'utf-8'}
-                encoding = detect(data)['encoding']
+            with open(args.filename, 'rb') as fp:
+                data = fp.read()
     else:
         data = wrap_read()
 
-    if hasattr(data, 'decode'):
-        try:
-            data = data.decode(encoding, options.decode_errors)
-        except UnicodeDecodeError as err:
-            warning = bcolors.WARNING + "Warning:" + bcolors.ENDC
-            warning += ' Use the ' + bcolors.OKGREEN
-            warning += '--decode-errors=ignore' + bcolors.ENDC + ' flag.'
-            print(warning)
-            raise err
+    try:
+        data = data.decode(args.encoding, args.decode_errors)
+    except UnicodeDecodeError as err:
+        warning = bcolors.WARNING + "Warning:" + bcolors.ENDC
+        warning += ' Use the ' + bcolors.OKGREEN
+        warning += '--decode-errors=ignore' + bcolors.ENDC + ' flag.'
+        print(warning)
+        raise err
 
     h = HTML2Text(baseurl=baseurl)
     # handle options
-    if options.ul_style_dash:
+    if args.ul_style_dash:
         h.ul_item_mark = '-'
-    if options.em_style_asterisk:
+    if args.em_style_asterisk:
         h.emphasis_mark = '*'
         h.strong_mark = '__'
 
-    h.body_width = options.body_width
-    h.google_list_indent = options.list_indent
-    h.ignore_emphasis = options.ignore_emphasis
-    h.ignore_links = options.ignore_links
-    h.protect_links = options.protect_links
-    h.ignore_images = options.ignore_images
-    h.images_as_html = options.images_as_html
-    h.images_to_alt = options.images_to_alt
-    h.images_with_size = options.images_with_size
-    h.google_doc = options.google_doc
-    h.hide_strikethrough = options.hide_strikethrough
-    h.escape_snob = options.escape_snob
-    h.bypass_tables = options.bypass_tables
-    h.ignore_tables = options.ignore_tables
-    h.single_line_break = options.single_line_break
-    h.inline_links = options.inline_links
-    h.unicode_snob = options.unicode_snob
-    h.use_automatic_links = options.use_automatic_links
-    h.skip_internal_links = options.skip_internal_links
-    h.links_each_paragraph = options.links_each_paragraph
-    h.mark_code = options.mark_code
-    h.wrap_links = options.wrap_links
-    h.wrap_list_items = options.wrap_list_items
-    h.pad_tables = options.pad_tables
-    h.default_image_alt = options.default_image_alt
-    h.open_quote = options.open_quote
-    h.close_quote = options.close_quote
+    h.body_width = args.body_width
+    h.google_list_indent = args.list_indent
+    h.ignore_emphasis = args.ignore_emphasis
+    h.ignore_links = args.ignore_links
+    h.protect_links = args.protect_links
+    h.ignore_images = args.ignore_images
+    h.images_as_html = args.images_as_html
+    h.images_to_alt = args.images_to_alt
+    h.images_with_size = args.images_with_size
+    h.google_doc = args.google_doc
+    h.hide_strikethrough = args.hide_strikethrough
+    h.escape_snob = args.escape_snob
+    h.bypass_tables = args.bypass_tables
+    h.ignore_tables = args.ignore_tables
+    h.single_line_break = args.single_line_break
+    h.inline_links = args.inline_links
+    h.unicode_snob = args.unicode_snob
+    h.use_automatic_links = args.use_automatic_links
+    h.skip_internal_links = args.skip_internal_links
+    h.links_each_paragraph = args.links_each_paragraph
+    h.mark_code = args.mark_code
+    h.wrap_links = args.wrap_links
+    h.wrap_list_items = args.wrap_list_items
+    h.pad_tables = args.pad_tables
+    h.default_image_alt = args.default_image_alt
+    h.open_quote = args.open_quote
+    h.close_quote = args.close_quote
 
     wrapwrite(h.handle(data))

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -90,8 +90,10 @@ def main():
         dest="images_as_html",
         action="store_true",
         default=config.IMAGES_AS_HTML,
-        help="Always write image tags as raw html; preserves `height`, `width` "
-             "and `alt` if possible."
+        help=(
+            "Always write image tags as raw html; preserves `height`, `width` "
+            "and `alt` if possible."
+        )
     )
     p.add_option(
         "--images-to-alt",

--- a/html2text/config.py
+++ b/html2text/config.py
@@ -14,7 +14,7 @@ ESCAPE_SNOB = 0
 # Put the links after each paragraph instead of at the end.
 LINKS_EACH_PARAGRAPH = 0
 
-# Wrap long lines at position. 0 for no wrapping. (Requires Python 2.3.)
+# Wrap long lines at position. 0 for no wrapping.
 BODY_WIDTH = 78
 
 # Don't show internal links (href="#local-anchor") -- corresponding link

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -12,7 +12,7 @@ def name2cp(k):
 
 
 unifiable_n = {}
-for k in config.UNIFIABLE.keys():
+for k in config.UNIFIABLE:
     unifiable_n[name2cp(k)] = config.UNIFIABLE[k]
 
 
@@ -30,12 +30,10 @@ def dumb_property_dict(style):
     """
     :returns: A hash of css attributes
     """
-    out = dict([(x.strip().lower(), y.strip().lower()) for x, y in
-                [z.split(':', 1) for z in
-                 style.split(';') if ':' in z
-                 ]
-                ]
-               )
+    out = {
+        x.strip().lower(): y.strip().lower()
+        for x, y in [z.split(':', 1) for z in style.split(';') if ':' in z]
+    }
 
     return out
 
@@ -59,8 +57,7 @@ def dumb_css_parser(data):
     # support older pythons
     elements = [x.split('{') for x in data.split('}') if '{' in x.strip()]
     try:
-        elements = dict([(a.strip(), dumb_property_dict(b))
-                         for a, b in elements])
+        elements = {a.strip(): dumb_property_dict(b) for a, b in elements}
     except ValueError:  # pragma: no cover
         elements = {}  # not that important
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 coverage==4.4.2
 py==1.5.2
-pypandoc==1.4
 wheel==0.30.0
 flake8==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,65 +1,23 @@
 # coding: utf-8
-import sys
-
-from setuptools import setup, Command, find_packages
+from setuptools import setup
 
 
-def read_md_convert(f):
-    return convert(f, 'rst')
-
-
-def read_md_open(f):
-    return open(f, 'r').read()
-
-
-try:
-    from pypandoc import convert
-    read_md = read_md_convert
-except ImportError:
-    read_md = read_md_open
-
-requires_list = []
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-else:
-    if sys.version_info <= (2, 6):
-        requires_list.append("unittest2")
-
-
-class RunTests(Command):
-    """
-    New setup.py command to run all tests for the package.
-    """
-    description = "run all tests for the package"
-
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        tests = unittest.TestLoader().discover('.')
-        runner = unittest.TextTestRunner()
-        results = runner.run(tests)
-        sys.exit(not results.wasSuccessful())
+def readall(f):
+    with open(f) as fp:
+        return fp.read()
 
 
 setup(
     name="html2text",
     version=".".join(map(str, __import__('html2text').__version__)),
     description="Turn HTML into equivalent Markdown-structured text.",
-    long_description=read_md('README.md'),
+    long_description=readall('README.md'),
+    long_description_content_type="text/markdown",
     author="Aaron Swartz",
     author_email="me@aaronsw.com",
     maintainer='Alireza Savand',
     maintainer_email='alireza.savand@gmail.com',
     url='https://github.com/Alir3z4/html2text/',
-    cmdclass={'test': RunTests},
     platforms='OS Independent',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -68,25 +26,23 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.4',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.0',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    entry_points="""
-        [console_scripts]
-        html2text=html2text.cli:main
-    """,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    entry_points={
+        'console_scripts': [
+            'html2text = html2text.cli:main',
+        ]
+    },
     license='GNU GPL 3',
-    requires=requires_list,
-    packages=find_packages(exclude=['test']),
+    packages=['html2text'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -6,11 +6,7 @@ import os
 import re
 import subprocess
 import sys
-
-if sys.version_info[:2] < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
@@ -79,7 +75,7 @@ def test_function(fn, **kwargs):
 
 
 def get_dump_name(fn, suffix):
-    return '%s-%s_output.md' % (os.path.splitext(fn)[0], suffix)
+    return '{}-{}_output.md'.format(os.path.splitext(fn)[0], suffix)
 
 
 def get_baseline_name(fn):
@@ -255,6 +251,3 @@ for fn in glob.glob("%s/*.html" % test_dir_name):
         setattr(TestHTML2Text, test_name + "_cmd", test_c)
     if test_func:
         setattr(TestHTML2Text, test_name + "_func", test_func)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_memleak.py
+++ b/test/test_memleak.py
@@ -1,10 +1,6 @@
 import html2text
 import logging
-import sys
-if sys.version_info[:2] < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',


### PR DESCRIPTION
Python 2.6 and 3.3 are end of life. They are no longer receiving bug
fixes, including for security issues. Python 2.6 went EOL on 2013-10-29
and on 2017-09-29. For additional details on support Python versions,
see:

Supported: https://devguide.python.org/#status-of-python-branches
EOL: https://devguide.python.org/devcycle/#end-of-life-branches

Removing support for EOL Pythons will reduce testing and maintenance
resources while allowing the library to move towards a modern Python 3
style.

Using pypinfo, we can show the PyPI download statistics, show very low
numbers for EOL Pythons.

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  60.79% |        251,480 |
| 3.6            |  29.19% |        120,760 |
| 3.5            |   6.70% |         27,712 |
| 3.7            |   2.64% |         10,928 |
| 3.4            |   0.67% |          2,790 |
| 2.6            |   0.01% |             27 |
| 3.8            |   0.01% |             21 |
| 3.2            |   0.00% |              1 |
| 3.3            |   0.00% |              1 |
| Total          |         |        413,720 |

This allows for some code clean ups:

- Modern setuptools provides a test command
- Modern setuptools supports Markdown with long_description_content_type
- unittest2 features are now always included by default
- textwrap is always available
- Can use automatic positions in string formatting
- Can use dict comprehensions
- Use python_requires to guard against outdated Pythons
- Use context manager for `open()`
- Assume `.decode()` method exists
- Upgrade deprecated optparse to argparse

For additional opinions for why it would be good to drop Python 2.6, see:

https://snarky.ca/stop-using-python-2-6/
http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
https://hugovk.github.io/drop-python/2.6/