### PR TITLE
Removed long deprecated support for retrieving HTML over the network

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,7 @@
 * Fix #201: handle &lrm;/&rlm; marks mid-text within stressed tags or right after stressed tags.
 * Feature #213: `images_as_html` config option to always generate an `img` html tag. preserves "height", "width" and "alt" if possible.
 * Remove support for end-of-life Pythons. Now requires Python 2.7 or 3.4+.
+* Remove support for retrieving HTML over the network.
 
 2018.1.9
 ========

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 html2text is a Python script that converts a page of HTML into clean, easy-to-read plain ASCII text. Better yet, that ASCII also happens to be valid Markdown (a text-to-HTML format).
 
 
-Usage: `html2text [(filename|url) [encoding]]`
+Usage: `html2text [filename [encoding]]`
 
 | Option                                                 | Description
 |--------------------------------------------------------|---------------------------------------------------

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -1,7 +1,5 @@
 import argparse
-import warnings
 
-from html2text.compat import urllib
 from html2text import HTML2Text, config, __version__
 from html2text.utils import wrapwrite, wrap_read
 
@@ -245,19 +243,8 @@ def main():
     args = p.parse_args()
 
     if args.filename and args.filename != '-':  # pragma: no cover
-        if (args.filename.startswith('http://') or
-                args.filename.startswith('https://')):
-            warnings.warn(
-                "Support for retrieving html over network is set for "
-                "deprecation by version (2017, 1, x)",
-                DeprecationWarning
-            )
-            baseurl = args.filename
-            j = urllib.urlopen(baseurl)
-            data = j.read()
-        else:
-            with open(args.filename, 'rb') as fp:
-                data = fp.read()
+        with open(args.filename, 'rb') as fp:
+            data = fp.read()
     else:
         data = wrap_read()
 

--- a/html2text/compat.py
+++ b/html2text/compat.py
@@ -5,17 +5,15 @@ if sys.version_info[0] == 2:
     import htmlentitydefs
     import urlparse
     import HTMLParser
-    import urllib
     from cgi import escape as html_escape
 else:
     import urllib.parse as urlparse
     import html.entities as htmlentitydefs
     import html.parser as HTMLParser
-    import urllib.request as urllib
     from html import escape
 
     def html_escape(s):
         return escape(s, quote=False)
 
 
-__all__ = ['HTMLParser', 'html_escape', 'htmlentitydefs', 'urllib', 'urlparse']
+__all__ = ['HTMLParser', 'html_escape', 'htmlentitydefs', 'urlparse']


### PR DESCRIPTION
The feature was deprecated in commit
5672e2dd2c5bf918275acaf1142b36beba1b9ac5 (2016-05-27) and was originally
slated for removal in 2017.

Fixes #117 