### PR TITLE
Remove dead code from main() in cli.py

### DIFF
--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -267,24 +267,8 @@ def main():
             baseurl = file_
             j = urllib.urlopen(baseurl)
             data = j.read()
-            if encoding is None:
-                try:
-                    from feedparser import _getCharacterEncoding as enc
-                except ImportError:
-                    def enc(x, y):
-                        return ('utf-8', 1)
-                encoding = enc(j.headers, data)[0]
-                if encoding == 'us-ascii':
-                    encoding = 'utf-8'
         else:
             data = open(file_, 'rb').read()
-            if encoding is None:
-                try:
-                    from chardet import detect
-                except ImportError:
-                    def detect(x):
-                        return {'encoding': 'utf-8'}
-                encoding = detect(data)['encoding']
     else:
         data = wrap_read()
 


### PR DESCRIPTION
The dead code was guarded by `if encoding is None` however, encoding is
never None. Since commit 68a2b8ef4799be0705e42013c67996bcf06ee628,
encoding defaults to 'utf-8'. This dead code can be removed.

Fixes #220