### PR TITLE
Remove unnecessary `description-file = README.md` from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [bdist_wheel]
 universal = 1
-
-[metadata]
-description-file = README.md


### PR DESCRIPTION
setuptools include `README.md` as the description by default. For details, see:

https://github.com/pypa/setuptools/blob/6575418283ec605f6bca82c525f6680d897ce282/setuptools/command/sdist.py#L40-L41