### PR TITLE
Remove sitecustomize.py

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,9 +1,0 @@
-import os
-
-import coverage
-
-
-here = os.getcwd()
-config_file = os.path.join(here, '.coveragerc')
-os.environ['COVERAGE_PROCESS_START'] = config_file
-coverage.process_startup()


### PR DESCRIPTION
It is unnecessary and produces warnings when coverage is not installed,
such as in a virtualenv.

    Error in sitecustomize; set PYTHONVERBOSE for traceback:
    ModuleNotFoundError: No module named 'coverage'