### PR TITLE
Remove unused options from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,5 @@ setup(
     },
     license='GNU GPL 3',
     packages=['html2text'],
-    include_package_data=True,
-    zip_safe=False,
     test_suite='test',
 )


### PR DESCRIPTION
Remove include_package_data. The package does not contain any data
files, only Python files.

Remove zip_safe. As the package does not contains any data files, it is
zip safe.