### PR TITLE
Remove unused get_dump_name()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.py[co]
 *.bak
-test/*output.md
 build
 dist
 *.egg-info

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -69,10 +69,6 @@ def test_function(fn, **kwargs):
     return result, actual
 
 
-def get_dump_name(fn, suffix):
-    return '{}-{}_output.md'.format(os.path.splitext(fn)[0], suffix)
-
-
 def get_baseline_name(fn):
     return os.path.splitext(fn)[0] + '.md'
 


### PR DESCRIPTION
Unused since 9125b6c5261f5cb5fde5b9d22ee121d2920813bf. Nothing dumps
output files.