### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 language: python
+cache: pip
 python:
   - "2.7"
   - "3.4"


### PR DESCRIPTION
Reduce load on PyPI servers and slightly speed up builds.

For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache