### PR TITLE
Correct default tox matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     flake8
-    py{27,py34,py35,py36,py,py3}
+    py{27,34,35,36,37,py,py3}
 minversion = 1.9
 
 [testenv]


### PR DESCRIPTION
Previously was missing py37 and some targets had too many "py"
substrings.