### PR TITLE
Remove unused method unknown_decl

### DIFF
--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -129,7 +129,6 @@ The class defines methods:
     - soft_br
     - o
     - handle_data
-    - unknown_decl
     - charref
     - entityref
     - google_nest_count

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -835,10 +835,6 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.preceding_data = data
         self.o(data, 1)
 
-    def unknown_decl(self, data):  # pragma: no cover
-        # TODO: what is this doing here?
-        pass
-
     def charref(self, name):
         if name[0] in ['x', 'X']:
             c = int(name[1:], 16)


### PR DESCRIPTION
The function is empty, same as the parent class's implementation. Just
use inheritance rather than re-defining it.