### PR TITLE
Introduce isort for automated consistent sorting of Python imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: pip
 matrix:
   include:
     - env: TOXENV=flake8
+    - env: TOXENV=isort
     - python: "2.7"
       env: TOXENV=py27
     - python: "3.4"

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -1,30 +1,29 @@
 #!/usr/bin/env python
 # coding: utf-8
 """html2text: Turn HTML into equivalent Markdown-structured text."""
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
+
 import re
 import sys
 from textwrap import wrap
 
-from html2text.compat import urlparse, HTMLParser
 from html2text import config
-
+from html2text.compat import HTMLParser, urlparse
 from html2text.utils import (
-    name2cp,
-    unifiable_n,
-    google_text_emphasis,
-    google_fixed_width_font,
-    element_style,
-    hn,
-    google_has_height,
-    escape_md,
-    google_list_style,
-    list_numbering_start,
     dumb_css_parser,
+    element_style,
+    escape_md,
     escape_md_section,
+    google_fixed_width_font,
+    google_has_height,
+    google_list_style,
+    google_text_emphasis,
+    hn,
+    list_numbering_start,
+    name2cp,
+    pad_tables_in_text,
     skipwrap,
-    pad_tables_in_text
+    unifiable_n,
 )
 
 try:

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -1,7 +1,7 @@
 import argparse
 
-from html2text import HTML2Text, config, __version__
-from html2text.utils import wrapwrite, wrap_read
+from html2text import HTML2Text, __version__, config
+from html2text.utils import wrap_read, wrapwrite
 
 
 def main():

--- a/html2text/compat.py
+++ b/html2text/compat.py
@@ -1,6 +1,5 @@
 import sys
 
-
 if sys.version_info[0] == 2:
     import htmlentitydefs
     import urlparse

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [bdist_wheel]
 universal = 1
+
+[isort]
+combine_as_imports = True
+include_trailing_comma = True
+line_length = 88
+multi_line_output = 3

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -1,12 +1,12 @@
 import codecs
 import glob
-import html2text
 import os
-import pytest
 import re
 import subprocess
 import sys
 
+import html2text
+import pytest
 
 skip = object()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     flake8
+    isort
     py{27,34,35,36,37,py,py3}
 minversion = 1.9
 
@@ -16,4 +17,11 @@ commands =
     flake8
 deps =
     flake8
+skip_install = true
+
+[testenv:isort]
+commands =
+    isort --check-only --diff
+deps =
+    isort
 skip_install = true


### PR DESCRIPTION
This tool automates import sorting across Python files. This removes the
need for contributors to think about the project's styling preferences
for imports. Just let the tool do it instead.

isort is a well established tool used by many projects.

https://github.com/timothycrosley/isort