### PR TITLE
Remove shebang from __init__.py

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 """html2text: Turn HTML into equivalent Markdown-structured text."""
 from __future__ import division


### PR DESCRIPTION
The file is not executable, no should not be executed directly, but as

    python -m html2text ...

Or from the setuptools installed entry point.