### PR TITLE
Remove 'pragma' comments for a more accurate coverage report

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -90,9 +90,9 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.open_quote = config.OPEN_QUOTE  # covered in cli
         self.close_quote = config.CLOSE_QUOTE  # covered in cli
 
-        if out is None:  # pragma: no cover
+        if out is None:
             self.out = self.outtextf
-        else:  # pragma: no cover
+        else:
             self.out = out
 
         # empty list to store output characters before they are "joined"
@@ -209,7 +209,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         self.a list. If the set of attributes is not found, returns None
         :rtype: int
         """
-        if 'href' not in attrs:  # pragma: no cover
+        if 'href' not in attrs:
             return None
         i = -1
         for a in self.a:

--- a/html2text/cli.py
+++ b/html2text/cli.py
@@ -7,7 +7,7 @@ from html2text.utils import wrapwrite, wrap_read
 def main():
     baseurl = ''
 
-    class bcolors:  # pragma: no cover
+    class bcolors:
         HEADER = '\033[95m'
         OKBLUE = '\033[94m'
         OKGREEN = '\033[92m'
@@ -242,7 +242,7 @@ def main():
     p.add_argument('encoding', nargs='?', default='utf-8')
     args = p.parse_args()
 
-    if args.filename and args.filename != '-':  # pragma: no cover
+    if args.filename and args.filename != '-':
         with open(args.filename, 'rb') as fp:
             data = fp.read()
     else:

--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -20,7 +20,7 @@ def hn(tag):
     if tag[0] == 'h' and len(tag) == 2:
         try:
             n = int(tag[1])
-            if n in range(1, 10):  # pragma: no branch
+            if n in range(1, 10):
                 return n
         except ValueError:
             return 0
@@ -58,7 +58,7 @@ def dumb_css_parser(data):
     elements = [x.split('{') for x in data.split('}') if '{' in x.strip()]
     try:
         elements = {a.strip(): dumb_property_dict(b) for a, b in elements}
-    except ValueError:  # pragma: no cover
+    except ValueError:
         elements = {}  # not that important
 
     return elements
@@ -208,7 +208,7 @@ def wrapwrite(text):
         sys.stdout.write(text)
 
 
-def wrap_read():  # pragma: no cover
+def wrap_read():
     """
     :rtype: str
     """


### PR DESCRIPTION
It is okay that these lines are not yet tested, but we don't need to
hide that fact from the coverage report. As time goes on, we may add
tests for them. If that happens, it should be reflected in the coverage
metrics.