### PR TITLE
Simplify hn() function

### DIFF
--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -16,12 +16,10 @@ unifiable_n = {name2cp(k): v for k, v in config.UNIFIABLE.items() if k != "nbsp"
 
 def hn(tag):
     if tag[0] == "h" and len(tag) == 2:
-        try:
-            n = int(tag[1])
-            if n in range(1, 10):
-                return n
-        except ValueError:
-            return 0
+        n = tag[1]
+        if "0" < n <= "9":
+            return int(n)
+    return 0
 
 
 def dumb_property_dict(style):


### PR DESCRIPTION
The new form:

- Avoids the unnecessary `range()` call. On Python 2 this avoids building the data structure in memory.
- Avoids the `try`/`except` block. The comparison is required either way, so just do that from the start.
- Always explicitly return as a value. The old form sometimes fell through and returned `None`.

The new version is also slightly faster. Running the function through Python's `timeit` showed the following results:

old: 0.6434267910080962
new: 0.40665965899825096