### PR TITLE
Fix memory link when processing an abbr tag

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@
 * Fix long blockquotes wrapping.
 * Remove the trailing whitespaces that were added after wrapping list items & blockquotes.
 * Remove support for Python ≤ 3.4. Now requires Python 3.5+.
+* Fix memory link when processing a document containing a ``<abbr>`` tag.
 
 
 2019.8.11

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -430,7 +430,7 @@ class HTML2Text(html.parser.HTMLParser):
                 if self.abbr_title is not None:
                     self.abbr_list[self.abbr_data] = self.abbr_title
                     self.abbr_title = None
-                self.abbr_data = ""
+                self.abbr_data = None
 
         if tag == "q":
             if not self.quote:

--- a/test/test_memleak.py
+++ b/test/test_memleak.py
@@ -17,3 +17,10 @@ def test_empty_string():
     h2t.handle(INSTR)
     # And even less when the input is empty.
     assert h2t.handle("") == "\n\n"
+
+
+def test_abbr_data():
+    h2t = html2text.HTML2Text()
+    result = h2t.handle('<p>foo <abbr title="Three Letter Acronym">TLA</abbr> bar</p>')
+    assert result == "foo TLA bar\n\n  *[TLA]: Three Letter Acronym\n\n"
+    assert h2t.abbr_data is None


### PR DESCRIPTION
Previously, after the first `abbr` tag, the `abbr_data` attribute continued
to grow when processing additional data. Now set the attribute to `None`
to avoid appending the unused data.