### PR TITLE
Correct nested list syntax in changelog

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -20,11 +20,13 @@
 * Add ``__main__.py`` module to allow running the CLI using ``python -m html2text ...``.
 * Fix #238: correct spacing when a HTML entity follows a non-stressed tags which follow a stressed tag.
 * Remove unused or deprecated:
+
   * ``html2text.compat.escape()``
   * ``html2text.config.RE_UNESCAPE``
   * ``html2text.HTML2Text.replaceEntities()``
   * ``html2text.HTML2Text.unescape()``
   * ``html2text.unescape()``
+
 * Fix #208: handle LEFT-TO-RIGHT MARK after a stressed tag.
 
 


### PR DESCRIPTION
Need a space before and after the indented list.