### PR TITLE
Speed up skipwrap function

### DIFF
--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -162,7 +162,7 @@ def list_numbering_start(attrs: Dict[str, Optional[str]]) -> int:
 def skipwrap(para: str, wrap_links: bool, wrap_list_items: bool) -> bool:
     # If it appears to contain a link
     # don't wrap
-    if (len(config.RE_LINK.findall(para)) > 0) and not wrap_links:
+    if not wrap_links and config.RE_LINK.search(para):
         return True
     # If the text begins with four spaces or one tab, it's a code block;
     # don't wrap


### PR DESCRIPTION
Short-circuit evaluation when `wrap_links` is True (the default). Evaluating a boolean expression is much cheaper than searching a paragraph for a match.

Any link present in the paragraph causes the wrapping to be skipped. Instead of searching for all matches, stop at the first match.

---

Suggesting the PR after encountering a catastrophic case at work today. `html2text` took 3800 seconds to generate the plain-text version of a 20 MB HTML document that contained many `[]` and `()`. With this patch applied, it processes the input in less than 10 seconds.