### PR TITLE
Make padded tables more similar to pandoc's pipe_tables

### DIFF
--- a/html2text/utils.py
+++ b/html2text/utils.py
@@ -247,13 +247,14 @@ def reformat_table(lines: List[str], right_margin: int) -> List[str]:
                 x.rstrip() + (filler * (M - len(x.rstrip())))
                 for x, M in zip(cols, max_width)
             ]
+            new_lines.append("|-" + "|".join(new_cols) + "|")
         else:
             filler = " "
             new_cols = [
                 x.rstrip() + (filler * (M - len(x.rstrip())))
                 for x, M in zip(cols, max_width)
             ]
-        new_lines.append("|".join(new_cols))
+            new_lines.append("| " + "|".join(new_cols) + "|")
     return new_lines
 
 


### PR DESCRIPTION
I've been looking for a pure python replacement to pypandoc to convert HTML to markdown. I can't seem to find any configuration that would have pandoc and this package format tables in the same manner. This PR would make this project padded table look a lot like [pandoc's pipe tables](https://pandoc.org/MANUAL.html#extension-pipe_tables).