### PR TITLE
Simplify and update lint configurations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,15 +40,11 @@ html2text = py.typed
 
 [flake8]
 max_line_length = 88
-ignore =
-    E203
-    W503
+extend-ignore = E203
 
 [isort]
 combine_as_imports = True
-include_trailing_comma = True
-line_length = 88
-multi_line_output = 3
+profile = black
 
 [mypy]
 python_version = 3.5

--- a/test/test_html2text.py
+++ b/test/test_html2text.py
@@ -4,8 +4,9 @@ import re
 import subprocess
 import sys
 
-import html2text
 import pytest
+
+import html2text
 
 skip = object()
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ skip_install = true
 [testenv:isort]
 basepython = python3
 commands =
-    isort --check-only --diff
+    isort --check --diff .
 deps =
-    isort
+    isort >= 5.0.1
 skip_install = true
 
 [testenv:mypy]


### PR DESCRIPTION
- flake8 ignores W503 by default
- Use isort profile to simplify configuration
- Update isort CLI invocation for 5.* series