### PR TITLE
Don't add line breaks inside link names

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ The AUTHORS/Contributors are (and/or have been):
 * Jacek Kołodziej <kolodziejj@gmail.com>
 * Jonathan Vanasco <jonathan@findmeon.com>
 * Jon Dufresne <jon.dufresne@gmail.com>
+* Mike Borsetti
 
 Maintainer:
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,6 +3,7 @@ UNRELEASED
 ----
 
 * Feature #318: Make padded tables more similar to pandoc's pipe_tables.
+* Fix extra line breaks inside html link text (between '[' and ']')
 
 2020.1.16
 =========

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -334,7 +334,8 @@ class HTML2Text(html.parser.HTMLParser):
                     parent_style = self.tag_stack[-1][2]
 
         if hn(tag):
-            self.p()
+            if self.outtextlist[-1] != '[':
+                self.p()
             if start:
                 self.inheader = True
                 self.o(hn(tag) * "#" + " ")

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -348,7 +348,7 @@ class HTML2Text(html.parser.HTMLParser):
                     self.p()
                 else:
                     self.soft_br()
-            elif self.astack and tag == "div":
+            elif self.astack:
                 pass
             else:
                 self.p()
@@ -484,6 +484,7 @@ class HTML2Text(html.parser.HTMLParser):
                             self.empty_link = False
                             self.maybe_automatic_link = None
                         if self.inline_links:
+                            self.p_p = 0
                             title = a.get("title") or ""
                             title = escape_md(title)
                             link_url(self, a["href"], title)

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -334,14 +334,28 @@ class HTML2Text(html.parser.HTMLParser):
                     parent_style = self.tag_stack[-1][2]
 
         if hn(tag):
-            if self.outtextlist[-1] != '[':
-                self.p()
-            if start:
-                self.inheader = True
-                self.o(hn(tag) * "#" + " ")
+            # check if nh is inside of an 'a' tag (incorrect but found in the wild)
+            if self.astack:
+                if start:
+                    self.inheader = True
+                    # are inside link name, so only add '#' if it can appear before '['
+                    if self.outtextlist and self.outtextlist[-1] == '[':
+                        self.outtextlist.pop()
+                        self.space = False
+                        self.o(hn(tag) * "#" + " ")
+                        self.o('[')
+                else:
+                    self.p_p = 0  # don't break up link name
+                    self.inheader = False
+                    return  # prevent redundant emphasis marks on headers
             else:
-                self.inheader = False
-                return  # prevent redundant emphasis marks on headers
+                self.p()
+                if start:
+                    self.inheader = True
+                    self.o(hn(tag) * "#" + " ")
+                else:
+                    self.inheader = False
+                    return  # prevent redundant emphasis marks on headers
 
         if tag in ["p", "div"]:
             if self.google_doc:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -339,11 +339,11 @@ class HTML2Text(html.parser.HTMLParser):
                 if start:
                     self.inheader = True
                     # are inside link name, so only add '#' if it can appear before '['
-                    if self.outtextlist and self.outtextlist[-1] == '[':
+                    if self.outtextlist and self.outtextlist[-1] == "[":
                         self.outtextlist.pop()
                         self.space = False
                         self.o(hn(tag) * "#" + " ")
-                        self.o('[')
+                        self.o("[")
                 else:
                     self.p_p = 0  # don't break up link name
                     self.inheader = False

--- a/test/empty-link.md
+++ b/test/empty-link.md
@@ -2,7 +2,5 @@
 
 This test checks whether empty hyperlinks still appear in the markdown result.
 
-[](http://some.link)
-
-[](http://some.link)
+[](http://some.link) [](http://some.link)
 

--- a/test/link_titles.html
+++ b/test/link_titles.html
@@ -1,3 +1,3 @@
 <a href="http://example.com" title="MyTitle"> first example</a>
 <br>
-<a href="http://example.com" > second example</a>
+<a href="http://example.com" ><p> second example</p></a>


### PR DESCRIPTION
The following HTML code
```
<a href="http://example.com" title="MyTitle"> first example</a>
<br>
<a href="http://example.com" ><p> second example</p></a>
```

is being converted by `html2text` version (2020, 1, 16) to the following Markdown (notice in the second example the line break before the closing `]`):
```
[ first example](http://example.com "MyTitle")  

[ second example

](http://example.com)
```

or with inline_links = False:
```
[ first example][1]  

[ second example

][2]

   [1]: http://example.com (MyTitle)

   [2]: http://example.com
```

The additional line break, besides looking askew, doesn't seem to be allowed by the official [specs](https://daringfireball.net/projects/markdown/syntax#link), and indeed breaks converting Markdown back to HTML.

This PR fixes the code to produce the following **correct** Markdown:
```
[ first example](http://example.com "MyTitle")  
[ second example](http://example.com)
```

or with inline_links = False:
```
[ first example][1]  
[ second example][2]

   [1]: http://example.com (MyTitle)

   [2]: http://example.com
```



Python 3.9 code to replicate the above:
```
import html2text
print(f'{html2text.__version__=}')
data = ('<a href="http://example.com" title="MyTitle"> first example</a>\n'
        '<br>\n'
        '<a href="http://example.com" ><p> second example</p></a>')
parser = html2text.HTML2Text()
markdown = parser.handle(data)
print(markdown)
parser.inline_links = False
markdown = parser.handle(data)
print(markdown)
```
