### PR TITLE
#163 : Fix extra newlines bug on multiple use of same html2text object

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -142,6 +142,7 @@ class HTML2Text(html.parser.HTMLParser):
         super().feed(data)
 
     def handle(self, data: str) -> str:
+        self.start = True
         self.feed(data)
         self.feed("")
         markdown = self.optwrap(self.finish())

--- a/test/test_newlines_on_multiple_calls.py
+++ b/test/test_newlines_on_multiple_calls.py
@@ -1,0 +1,10 @@
+import html2text
+
+# See https://github.com/Alir3z4/html2text/issues/163 for more information.
+
+
+def test_newline_on_multiple_calls():
+    h = html2text.HTML2Text()
+    md1 = h.handle("<p>test</test>")
+    md2 = h.handle("<p>test</test>")
+    assert md1 == md2

--- a/test/test_newlines_on_multiple_calls.py
+++ b/test/test_newlines_on_multiple_calls.py
@@ -5,6 +5,8 @@ import html2text
 
 def test_newline_on_multiple_calls():
     h = html2text.HTML2Text()
-    md1 = h.handle("<p>test</test>")
-    md2 = h.handle("<p>test</test>")
-    assert md1 == md2
+    html = "<p>test</p>"
+    md1 = h.handle(html)
+    md2 = h.handle(html)
+    md3 = h.handle(html)
+    assert md1 == md2 == md3


### PR DESCRIPTION
# #163 

- The bug was being caused since `self.start` was retaining the `False` value
- I've added tests to ensure this does not regress.