### PR TITLE
Fixed broken link of docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 </tbody>
 </table>
 
-<p>For a complete list of options see the <a href="docs/usage.md">docs</a></p>
+<p>For a complete list of options see the <a href="https://github.com/Alir3z4/html2text/blob/master/docs/usage.md">docs</a></p>
 
 <p>Or you can use it from within <code>Python</code>:</p>
 


### PR DESCRIPTION
## [# 205](https://github.com/Alir3z4/html2text/issues/205)

I have changed the link of docs to https://github.com/Alir3z4/html2text/blob/master/docs/usage.md 