### PR TITLE
Handle space correct on inline tags within stressed texts

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -130,7 +130,8 @@ class HTML2Text(html.parser.HTMLParser):
         # Stack of abbreviations to write later
         self.abbr_list = {}  # type: Dict[str, str]
         self.baseurl = baseurl
-        self.stressed = False
+        self.start_stressed = False
+        self.within_stressed_cnt = 0
         self.preceding_stressed = False
         self.preceding_data = ""
         self.current_tag = ""
@@ -407,6 +408,16 @@ class HTML2Text(html.parser.HTMLParser):
                 self.blockquote -= 1
                 self.p()
 
+        def enter_stressed():
+            if start:
+                self.start_stressed = True
+                self.within_stressed_cnt += 1
+            else:
+                self.within_stressed_cnt -= 1
+                self.start_stressed = False
+                self.preceding_stressed = True
+
+
         if tag in ["em", "i", "u"] and not self.ignore_emphasis:
             # Separate with a space if we immediately follow an alphanumeric
             # character, since otherwise Markdown won't render the emphasis
@@ -425,8 +436,7 @@ class HTML2Text(html.parser.HTMLParser):
                 emphasis = self.emphasis_mark
 
             self.o(emphasis)
-            if start:
-                self.stressed = True
+            enter_stressed()
 
         if tag in ["strong", "b"] and not self.ignore_emphasis:
             # Separate with space if we immediately follow an * character, since
@@ -444,8 +454,7 @@ class HTML2Text(html.parser.HTMLParser):
                 strong = self.strong_mark
 
             self.o(strong)
-            if start:
-                self.stressed = True
+            enter_stressed()
 
         if tag in ["del", "strike", "s"]:
             if start and self.preceding_data and self.preceding_data[-1] == "~":
@@ -455,8 +464,7 @@ class HTML2Text(html.parser.HTMLParser):
                 strike = "~~"
 
             self.o(strike)
-            if start:
-                self.stressed = True
+            enter_stressed()
 
         if self.google_doc:
             if not self.inheader:
@@ -852,10 +860,15 @@ class HTML2Text(html.parser.HTMLParser):
             # LEFT-TO-RIGHT MARK.
             return
 
-        if self.stressed:
-            data = data.strip()
-            self.stressed = False
-            self.preceding_stressed = True
+        stripped_data = data.strip()
+        if self.start_stressed:
+            data = stripped_data
+            self.start_stressed = False
+        elif self.within_stressed_cnt:
+            if stripped_data:
+                data = " " + stripped_data
+            else:
+                data = stripped_data
         elif self.preceding_stressed:
             if (
                 re.match(r"[^][(){}\s.!?]", data[0])

--- a/test/inline_within_stressed.html
+++ b/test/inline_within_stressed.html
@@ -1,0 +1,5 @@
+<p><b>TEXT <a href="http://test.org">LINK</a> </b></p>
+
+<p><b>TE<i>X</i>T </b></p>
+
+<p><b>TE<i>XT</i> </b></p>

--- a/test/inline_within_stressed.md
+++ b/test/inline_within_stressed.md
@@ -1,0 +1,6 @@
+**TEXT[ LINK](http://test.org)**
+
+**TE _X_ T**
+
+**TE _XT_**
+


### PR DESCRIPTION
When including inline tags within stressed tags like
<strong> or <i> until now it was not guaranteed that
trailing spaces are removed. Furthermore it could happen
that spaces in the middle were removed under specific circumstances.

This ticket fixes #371 