### PR TITLE
Fix \n inside text of a Markdown link

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -354,7 +354,9 @@ class HTML2Text(html.parser.HTMLParser):
                 self.p()
 
         if tag == "br" and start:
-            if self.blockquote > 0:
+            if self.astack:
+                self.space = True
+            elif self.blockquote > 0:
                 self.o("  \n> ")
             else:
                 self.o("  \n")

--- a/test/br_inside_a.html
+++ b/test/br_inside_a.html
@@ -1,0 +1,1 @@
+<a href="https://example.org/">This is a<br>test</a>

--- a/test/br_inside_a.md
+++ b/test/br_inside_a.md
@@ -1,0 +1,1 @@
+[This is a test](https://example.com)


### PR DESCRIPTION
Fix Markdown links being broken by HTML where the link text includes a `<br>` (as seen in the wild).

Example:
```
<a href="https://example.org/">This is a<br>test</a>`
``` 
is output as
```
[This is a
test](https://example.com)
```
Whis is **not** a Markdown link.

After this PR the output is:
```
[This is a test](https://example.com)
```
Whis is a **valid** Markdown link.
