### PR TITLE
Fix tables with empty first cell

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -693,7 +693,7 @@ class HTML2Text(html.parser.HTMLParser):
                             self.o("</" + config.TABLE_MARKER_FOR_PAD + ">")
                             self.o("  \n")
                 if tag in ["td", "th"] and start:
-                    if self.split_next_td:
+                    if self.split_next_td or self.table_start:
                         self.o("| ")
                     self.split_next_td = True
 


### PR DESCRIPTION
Hello

This PR fixes an issue where an empty first cell in a table results in markdown tables which do parse properly.

For example:

```html
<table>
  <tr><th></th><th>b></th></td>
  <tr><td></td><td>b></td></td>
</table>
```

results in the following output:

```
| b
---|---
c | d
```

which is not a valid markdown table:

| b
---|---
c | d

---

With this fix, the output is:

```
|  | b
---|---
c | d
```
which renders correctly:

|  | b
---|---
c | d