### PR TITLE
Treat white-space: pre-wrap as a pre tag

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -710,7 +710,7 @@ class HTML2Text(html.parser.HTMLParser):
                 if tag in ["td", "th"] and start:
                     self.td_count += 1
 
-        if tag == "pre":
+        if tag == "pre" or element_style(attrs, self.style_def, {}).get("white-space", "") == "pre-wrap":
             if start:
                 self.startpre = True
                 self.pre = True


### PR DESCRIPTION
div tags which are styled with white-space: pre-wrap should be treated the same way that pre tags are.